### PR TITLE
fix broken language support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -714,21 +714,11 @@
       }
     },
     "@types/i18next-fs-backend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/i18next-fs-backend/-/i18next-fs-backend-1.0.1.tgz",
-      "integrity": "sha512-zJDqz/xg3j2qJNr4t+fUgGEC30Xq/rqM8iF8sraN/nBVwIoItcpUwc/Wvwqs9pEgNpDgZ0PXRoWhoicwozSM3g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/i18next-fs-backend/-/i18next-fs-backend-1.1.1.tgz",
+      "integrity": "sha512-rj95Ng1UmDSHiFPXOGX95c760LUOYj5MyYuxeXleWNCkeOVZJVpVKTEL6bTPeBK8A+GSnFeOnoNNkdmM2wUjTg==",
       "requires": {
-        "i18next": "^19.7.0"
-      },
-      "dependencies": {
-        "i18next": {
-          "version": "19.9.2",
-          "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.9.2.tgz",
-          "integrity": "sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==",
-          "requires": {
-            "@babel/runtime": "^7.12.0"
-          }
-        }
+        "i18next": "^20.6.1"
       }
     },
     "@types/json-schema": {
@@ -4618,9 +4608,9 @@
       "integrity": "sha512-OjJ+fV15FXO2uQXQagLD4C0abYErBjyjE0I0FHpOEIB8upw0hg1ldFP6cqHTJBH1cZqy96OeR3u1dJ+Ez2D4Bg=="
     },
     "next-i18next": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-8.8.0.tgz",
-      "integrity": "sha512-zCV8VU2t/BfrGrxULAGoK8exDTKaXCexKl5plcu0x1yDCvywaXwPXwDVYOc4LaU3rmUufiAbFM+YM2GWz5g1oA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-8.4.0.tgz",
+      "integrity": "sha512-QwUXDMOnguEWSrbA6fPDBReiQG0kgXm/c69R3u21ClrurT/7JJwNm2qUhtsY3+EZDC4O/7mFXK3lRrSszgf5BA==",
       "requires": {
         "@babel/runtime": "^7.13.17",
         "@types/hoist-non-react-statics": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "geocoder-arcgis": "^2.0.5",
     "next": "^11.1.1",
     "next-compose-plugins": "^2.2.1",
-    "next-i18next": "^8.4.0",
+    "next-i18next": "8.4.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "6.14.2",


### PR DESCRIPTION
Changes in this pull request:
- keep next-i18next fixed to version 8.4.0 to avoid not loading all resources in the Frontend (not working on version 8.8.0)