### PR TITLE
Fixes for Bouquet donation process

### DIFF
--- a/src/Donations/Micros/DonationTypes/BouquetDonations.tsx
+++ b/src/Donations/Micros/DonationTypes/BouquetDonations.tsx
@@ -36,9 +36,9 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
     if (e.target) {
       if (e.target.value === "" || e.target.value < 1) {
         // if input is '', default 1
-        setquantity(1 / paymentSetup.unitCost);
+        setquantity(paymentSetup.unitBased ? 1 / paymentSetup.unitCost : 1);
       } else if (e.target.value.toString().length <= 12) {
-        setquantity(e.target.value / paymentSetup.unitCost);
+        setquantity(paymentSetup.unitBased ? e.target.value / paymentSetup.unitCost : e.target.value);
       }
     }
   };
@@ -53,7 +53,10 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
         newallOptionsArray.push(option.quantity);
       }
       if (!newallOptionsArray.includes(quantity)) {
-        setCustomInputValue(quantity * paymentSetup.unitCost);
+        setCustomInputValue(paymentSetup.unitBased ? quantity * paymentSetup.unitCost : quantity);
+        setisCustomDonation(true);
+      } else {
+        setisCustomDonation(false);
       }
     }
   }, [paymentSetup]);
@@ -141,7 +144,8 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
                   className={"funding-custom-tree-input"}
                   onInput={(e) => {
                     // replaces any character other than number to blank
-                    e.target.value = e.target.value.replace(/[^0-9]/g, "");
+                    e.target.value = e.target.value.replace(/[,]/g, '.');
+                    e.target.value = e.target.value.replace(/[^0-9\.]/g, "");
                     //  if length of input more than 12, display only 12 digits
                     if (e.target.value.toString().length >= 12) {
                       e.target.value = e.target.value.toString().slice(0, 12);

--- a/src/Donations/Micros/DonationTypes/BouquetDonations.tsx
+++ b/src/Donations/Micros/DonationTypes/BouquetDonations.tsx
@@ -68,14 +68,15 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
         newallOptionsArray.push(option.quantity);
       }
       //if (!newallOptionsArray.includes(quantity)) {
-        //setCustomInputValue(
-          //paymentSetup.unitBased ? quantity * paymentSetup.unitCost : quantity
-        //);
-        //setisCustomDonation(true);
+      //setCustomInputValue(
+      //paymentSetup.unitBased ? quantity * paymentSetup.unitCost : quantity
+      //);
+      //setisCustomDonation(true);
       //} else {
-        //setisCustomDonation(false);}
+      //setisCustomDonation(false);}
       if (!newallOptionsArray.includes(paymentSetup.options[1].quantity)) {
         setCustomInputValue(quantity);
+      }
     }
   }, [paymentSetup]);
 
@@ -90,9 +91,8 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
   return (
     <>
       <div
-        className={`funding-selection-options-container ${
-          isGift && giftDetails.recipientName === "" ? "display-none" : ""
-        }`}
+        className={`funding-selection-options-container ${isGift && giftDetails.recipientName === "" ? "display-none" : ""
+          }`}
       >
         {paymentSetup.options &&
           paymentSetup.options.slice(0, 6).map((option, index) => {
@@ -104,11 +104,10 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
                   setisCustomDonation(false);
                   setCustomInputValue("");
                 }}
-                className={`funding-selection-option ${
-                  option.quantity === quantity && !isCustomDonation
+                className={`funding-selection-option ${option.quantity === quantity && !isCustomDonation
                     ? "funding-selection-option-selected"
                     : ""
-                }`}
+                  }`}
                 style={{ maxWidth: "100px" }}
               >
                 {/* <div
@@ -128,9 +127,8 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
 
         {paymentSetup && paymentSetup.options && (
           <div
-            className={`funding-selection-option ${
-              isCustomDonation ? "funding-selection-option-selected" : ""
-            }`}
+            className={`funding-selection-option ${isCustomDonation ? "funding-selection-option-selected" : ""
+              }`}
             onClick={() => {
               setisCustomDonation(true);
               customInputRef.current.focus();

--- a/src/Donations/Micros/DonationTypes/BouquetDonations.tsx
+++ b/src/Donations/Micros/DonationTypes/BouquetDonations.tsx
@@ -38,7 +38,11 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
         // if input is '', default 1
         setquantity(paymentSetup.unitBased ? 1 / paymentSetup.unitCost : 1);
       } else if (e.target.value.toString().length <= 12) {
-        setquantity(paymentSetup.unitBased ? e.target.value / paymentSetup.unitCost : e.target.value);
+        setquantity(
+          paymentSetup.unitBased
+            ? e.target.value / paymentSetup.unitCost
+            : e.target.value
+        );
       }
     }
   };
@@ -53,7 +57,9 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
         newallOptionsArray.push(option.quantity);
       }
       if (!newallOptionsArray.includes(quantity)) {
-        setCustomInputValue(paymentSetup.unitBased ? quantity * paymentSetup.unitCost : quantity);
+        setCustomInputValue(
+          paymentSetup.unitBased ? quantity * paymentSetup.unitCost : quantity
+        );
         setisCustomDonation(true);
       } else {
         setisCustomDonation(false);
@@ -144,8 +150,8 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
                   className={"funding-custom-tree-input"}
                   onInput={(e) => {
                     // replaces any character other than number to blank
-                    e.target.value = e.target.value.replace(/[,]/g, '.');
-                    e.target.value = e.target.value.replace(/[^0-9\.]/g, "");
+                    // e.target.value = e.target.value.replace(/[,]/g, '.');
+                    e.target.value = e.target.value.replace(/[^0-9]/g, "");
                     //  if length of input more than 12, display only 12 digits
                     if (e.target.value.toString().length >= 12) {
                       e.target.value = e.target.value.toString().slice(0, 12);

--- a/src/Donations/Micros/DonationTypes/BouquetDonations.tsx
+++ b/src/Donations/Micros/DonationTypes/BouquetDonations.tsx
@@ -67,15 +67,13 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
       for (const option of paymentSetup.options) {
         newallOptionsArray.push(option.quantity);
       }
-      //if (!newallOptionsArray.includes(quantity)) {
-      //setCustomInputValue(
-      //paymentSetup.unitBased ? quantity * paymentSetup.unitCost : quantity
-      //);
-      //setisCustomDonation(true);
-      //} else {
-      //setisCustomDonation(false);}
       if (!newallOptionsArray.includes(paymentSetup.options[1].quantity)) {
-        setCustomInputValue(quantity);
+        setCustomInputValue(
+          paymentSetup.unitBased ? quantity * paymentSetup.unitCost : quantity
+        );
+        setisCustomDonation(true);
+      } else {
+        setisCustomDonation(false);
       }
     }
   }, [paymentSetup]);
@@ -91,8 +89,9 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
   return (
     <>
       <div
-        className={`funding-selection-options-container ${isGift && giftDetails.recipientName === "" ? "display-none" : ""
-          }`}
+        className={`funding-selection-options-container ${
+          isGift && giftDetails.recipientName === "" ? "display-none" : ""
+        }`}
       >
         {paymentSetup.options &&
           paymentSetup.options.slice(0, 6).map((option, index) => {
@@ -104,10 +103,11 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
                   setisCustomDonation(false);
                   setCustomInputValue("");
                 }}
-                className={`funding-selection-option ${option.quantity === quantity && !isCustomDonation
+                className={`funding-selection-option ${
+                  option.quantity === quantity && !isCustomDonation
                     ? "funding-selection-option-selected"
                     : ""
-                  }`}
+                }`}
                 style={{ maxWidth: "100px" }}
               >
                 {/* <div
@@ -127,8 +127,9 @@ function FundingDonations({ setopenCurrencyModal }: Props): ReactElement {
 
         {paymentSetup && paymentSetup.options && (
           <div
-            className={`funding-selection-option ${isCustomDonation ? "funding-selection-option-selected" : ""
-              }`}
+            className={`funding-selection-option ${
+              isCustomDonation ? "funding-selection-option-selected" : ""
+            }`}
             onClick={() => {
               setisCustomDonation(true);
               customInputRef.current.focus();


### PR DESCRIPTION
Changes to fix errors in Bouquet donations process:
- allow to enter decimal numbers (replace "," with "." as we have not i18n number parser)
- do not apply paymentSetup.unitCost any more on quantity

To-Do:
- [x] form is always filled with initial default amount of 50 in every currency (as default number of trees is set as 50)
- [ ] currencies as ALL (Albania) can use lower amount as given minimum donation limit (bug also on production)