### PR TITLE
fix Treecounter donations with PayPal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@material-ui/core": "^4.11.3",
         "@material-ui/lab": "^4.0.0-alpha.57",
         "@next/bundle-analyzer": "^10.1.3",
-        "@paypal/react-paypal-js": "^6.0.1",
+        "@paypal/react-paypal-js": "^7.5.0",
         "@sentry/browser": "^6.2.5",
         "@sentry/integrations": "^6.2.5",
         "@sentry/node": "^6.2.5",
@@ -1408,20 +1408,20 @@
       }
     },
     "node_modules/@paypal/paypal-js": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-3.1.11.tgz",
-      "integrity": "sha512-glqLa8i9HaXYufYdlP4UGxlL1AcsVmKx0GEK6nkOP33DJoBJ6CfGlkLoZaK3AD+XTnwWRAQL/TAt99lMNFXqvw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-4.2.1.tgz",
+      "integrity": "sha512-5b+UykL8+WNOEWHgC2nGJUR9EMmRJNspVBjT7knZcItTP9sQeQ7lCGoM5yubFDMeVmhmCZDtJDASpwlo9VOcJg==",
       "dependencies": {
-        "promise-polyfill": "^8.2.0"
+        "promise-polyfill": "^8.2.1"
       }
     },
     "node_modules/@paypal/react-paypal-js": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-6.0.2.tgz",
-      "integrity": "sha512-zmGMgrHVoTdinfCHNIZBvsL3wRuc56lqm/NQn9oUUFh72V9Qdz6pE/gRqzmT5ECO4tR1VmJon+/izzVMW0GLug==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-7.5.0.tgz",
+      "integrity": "sha512-QWA0FArj4DG8WcyWZuQ/m7r4tI3Z3AF8Q/1cN8ANjUljjq7crvYu1a7WlRoBiwRQqaERXNjAZ3Ch+f22KRFGMA==",
       "dependencies": {
-        "@paypal/paypal-js": "^3.1.11",
-        "@paypal/sdk-constants": "^1.0.106"
+        "@paypal/paypal-js": "^4.2.1",
+        "@paypal/sdk-constants": "^1.0.110"
       },
       "peerDependencies": {
         "react": ">=16.3.0",
@@ -9301,20 +9301,20 @@
       }
     },
     "@paypal/paypal-js": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-3.1.11.tgz",
-      "integrity": "sha512-glqLa8i9HaXYufYdlP4UGxlL1AcsVmKx0GEK6nkOP33DJoBJ6CfGlkLoZaK3AD+XTnwWRAQL/TAt99lMNFXqvw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@paypal/paypal-js/-/paypal-js-4.2.1.tgz",
+      "integrity": "sha512-5b+UykL8+WNOEWHgC2nGJUR9EMmRJNspVBjT7knZcItTP9sQeQ7lCGoM5yubFDMeVmhmCZDtJDASpwlo9VOcJg==",
       "requires": {
-        "promise-polyfill": "^8.2.0"
+        "promise-polyfill": "^8.2.1"
       }
     },
     "@paypal/react-paypal-js": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-6.0.2.tgz",
-      "integrity": "sha512-zmGMgrHVoTdinfCHNIZBvsL3wRuc56lqm/NQn9oUUFh72V9Qdz6pE/gRqzmT5ECO4tR1VmJon+/izzVMW0GLug==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@paypal/react-paypal-js/-/react-paypal-js-7.5.0.tgz",
+      "integrity": "sha512-QWA0FArj4DG8WcyWZuQ/m7r4tI3Z3AF8Q/1cN8ANjUljjq7crvYu1a7WlRoBiwRQqaERXNjAZ3Ch+f22KRFGMA==",
       "requires": {
-        "@paypal/paypal-js": "^3.1.11",
-        "@paypal/sdk-constants": "^1.0.106"
+        "@paypal/paypal-js": "^4.2.1",
+        "@paypal/sdk-constants": "^1.0.110"
       }
     },
     "@paypal/sdk-constants": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@material-ui/core": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@next/bundle-analyzer": "^10.1.3",
-    "@paypal/react-paypal-js": "^6.0.1",
+    "@paypal/react-paypal-js": "^7.5.0",
     "@sentry/browser": "^6.2.5",
     "@sentry/integrations": "^6.2.5",
     "@sentry/node": "^6.2.5",

--- a/src/Donations/Components/PaymentsForm.tsx
+++ b/src/Donations/Components/PaymentsForm.tsx
@@ -93,7 +93,7 @@ function PaymentsForm({}: Props): ReactElement {
   ) => {
     let token = null;
     if ((!isLoading && isAuthenticated) || queryToken) {
-      token = await getAccessTokenSilently();
+      token = queryToken ? queryToken : await getAccessTokenSilently();
     }
     payDonationFunction({
       gateway,


### PR DESCRIPTION
Fixes problem not being able to finish donation e.g. with PayPal for logged in user of native Treecounter-App:

Changes in this pull request:
- use the token given by the queryToken parameter
- upgraded PayPal module (not necessary for the bugfix)

Test requires using Treecounter app with a logged in user and donate e.g. with PayPal.