### PR TITLE
Locale in query params

### DIFF
--- a/src/Donations/PaymentMethods/PaymentFunctions.ts
+++ b/src/Donations/PaymentMethods/PaymentFunctions.ts
@@ -170,7 +170,7 @@ export function createDonationData({
         : amount,
     currency,
     donor: { ...contactDetails },
-    frequency: frequency === "once" ? null : frequency,
+    frequency: frequency,
     metadata: {
       callback_url: callbackUrl,
       callback_method: callbackMethod,

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -299,7 +299,7 @@ export default function QueryParamProvider({ children }: any) {
       const requestParams = {
         url: `/app/config`,
         setshowErrorCard,
-        tenantQueryParam: false,
+        shouldQueryParamAdd: false,
       };
       const config: any = await apiRequest(requestParams);
       if (config.data) {

--- a/src/Utils/api.ts
+++ b/src/Utils/api.ts
@@ -20,16 +20,6 @@ axiosInstance.interceptors.request.use(
     config.headers["Content-Type"] = "application/json";
     config.headers["X-ACCEPT-VERSION"] = "1.2";
 
-    if (typeof Storage !== "undefined") {
-      config.headers["x-locale"] = `${
-        localStorage.getItem("language")
-          ? localStorage.getItem("language")
-          : "en"
-      }`;
-    } else {
-      config.headers["x-locale"] = "en";
-    }
-
     return config;
   },
   (error) => {
@@ -105,6 +95,15 @@ export const apiRequest = async (
     } else if (tenantQueryParam) {
       options.params = { tenant: "ten_I9TW3ncG" };
     }
+    let locale = "en";
+    if (typeof Storage !== "undefined") {
+      locale = `${
+        localStorage.getItem("language")
+          ? localStorage.getItem("language")
+          : "en"
+      }`;
+    }
+    options.params = { ...options.params, locale };
 
     // returns a promise with axios instance
     return new Promise((resolve, reject) => {

--- a/src/Utils/api.ts
+++ b/src/Utils/api.ts
@@ -45,7 +45,7 @@ interface RequestParams {
   token?: any;
   data?: any;
   setshowErrorCard: Function;
-  tenantQueryParam?: boolean;
+  shouldQueryParamAdd?: boolean;
   tenant?: string;
 }
 interface ExtendedRequestParams extends RequestParams {
@@ -61,7 +61,7 @@ export const apiRequest = async (
     data = undefined,
     token = false,
     setshowErrorCard,
-    tenantQueryParam = true,
+    shouldQueryParamAdd = true,
     tenant,
   } = extendedRequestParams;
 
@@ -88,22 +88,19 @@ export const apiRequest = async (
         Authorization: `Bearer ${token}`,
       };
     }
-    if (typeof Storage !== "undefined" && tenantQueryParam) {
-      options.params = {
-        tenant: tenant,
-      };
-    } else if (tenantQueryParam) {
-      options.params = { tenant: "ten_I9TW3ncG" };
-    }
-    let locale = "en";
-    if (typeof Storage !== "undefined") {
-      locale = `${
+    if (typeof Storage !== "undefined" && shouldQueryParamAdd) {
+      let locale = `${
         localStorage.getItem("language")
           ? localStorage.getItem("language")
           : "en"
       }`;
+      options.params = {
+        tenant: tenant,
+        locale,
+      };
+    } else if (shouldQueryParamAdd) {
+      options.params = { tenant: "ten_I9TW3ncG", locale: "en" };
     }
-    options.params = { ...options.params, locale };
 
     // returns a promise with axios instance
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Changes
- pass frequency 'once' for one-time donation
- added locale in query param instead of headers in all API calls