### PR TITLE
PayPal processing: Disable duplicate payment gateways

### DIFF
--- a/src/Donations/PaymentMethods/NewPaypal.tsx
+++ b/src/Donations/PaymentMethods/NewPaypal.tsx
@@ -27,8 +27,8 @@ function NewPaypal({
 }: Props): ReactElement {
   const initialOptions = {
     "client-id": paymentSetup?.gateways.paypal.authorization.client_id,
-    "enable-funding": "venmo,giropay,sofort",
-    "disable-funding": "card",
+    "enable-funding": "venmo",
+    "disable-funding": "card,giropay,sofort,sepa",
     currency: currency,
   };
 


### PR DESCRIPTION
PayPal processing: disable the following funding options: giropay, sofort, sepa (We already support these payment methods through Stripe with lower transaction fees)

Fixes #

Check this list and then dismiss it:

- [x] - **Localization**
- [x] - **Validation and error management**
- [x] - **Coding style**

Changes in this pull request:
- disable the following funding options: giropay, sofort, sepa

@