### PR TITLE
Avoid crash for missing lastname from Google Pay

### DIFF
--- a/src/Donations/Components/DonationsForm.tsx
+++ b/src/Donations/Components/DonationsForm.tsx
@@ -110,27 +110,29 @@ function DonationsForm() {
       frequency,
       tenant,
     }).then(async (res) => {
-      let token = null;
-      if ((!isLoading && isAuthenticated) || queryToken) {
-        token = queryToken ? queryToken : await getAccessTokenSilently();
+      if (res) {
+        let token = null;
+        if ((!isLoading && isAuthenticated) || queryToken) {
+          token = queryToken ? queryToken : await getAccessTokenSilently();
+        }
+        payDonationFunction({
+          gateway: "stripe",
+          method: "card", // Hard coding card here since we only have card enabled in gpay and apple pay
+          providerObject: paymentMethod, // payment method
+          setIsPaymentProcessing,
+          setPaymentError,
+          t,
+          paymentSetup,
+          donationID: res.id,
+          contactDetails,
+          token,
+          country,
+          setshowErrorCard,
+          router,
+          tenant,
+          setTransferDetails,
+        });
       }
-      payDonationFunction({
-        gateway: "stripe",
-        method: "card", // Hard coding card here since we only have card enabled in gpay and apple pay
-        providerObject: paymentMethod, // payment method
-        setIsPaymentProcessing,
-        setPaymentError,
-        t,
-        paymentSetup,
-        donationID: res.id,
-        contactDetails,
-        token,
-        country,
-        setshowErrorCard,
-        router,
-        tenant,
-        setTransferDetails,
-      });
     });
   };
 


### PR DESCRIPTION
Fixes #250

Changes in this pull request:
- check for res given before trying to pay donation

This does not make the error message better if the last name from Google Pay is missing, but just avoids a crash.