### PR TITLE
fix: resolve extra field error for direct gifts

### DIFF
--- a/src/Donations/Components/DonationsForm.tsx
+++ b/src/Donations/Components/DonationsForm.tsx
@@ -237,6 +237,11 @@ function DonationsForm() {
 
     delete _gift.giftMessage;
 
+    if (giftDetails.type === "direct") {
+      delete _gift.message;
+      delete _gift.recipientName;
+    }
+
     // create Donation data
     const donationData = {
       purpose: projectDetails!.purpose,

--- a/src/Donations/PaymentMethods/PaymentFunctions.ts
+++ b/src/Donations/PaymentMethods/PaymentFunctions.ts
@@ -209,7 +209,7 @@ export function createDonationData({
           gift: {
             type: "direct",
             recipientTreecounter: giftDetails.recipientTreecounter,
-            message: giftDetails.giftMessage,
+            // message: giftDetails.giftMessage, //A direct gift does not have a message
           },
         },
       };


### PR DESCRIPTION
`recipientName` is an invalid field while creating `direct-gift` donations. While creating donations with payment method PlanetCash, `recipientName` was being passed for both `direct-gift` and `invitation-gift` donations, resulting in a validation error response from `POST app/donations`. This fix resolves that issue. 

It also removes `message` from `direct-gift` donations as the value contained is always blank.