### PR TITLE
fix: fix crash due to null tpo name for project

### DIFF
--- a/src/Donations/Components/SelectProject.tsx
+++ b/src/Donations/Components/SelectProject.tsx
@@ -108,7 +108,9 @@ function SelectProject({}: Props): ReactElement {
                   />
                 ) : (
                   <div className="project-organisation-image no-project-organisation-image">
-                    {project.properties.tpo.name.charAt(0)}
+                    {project.properties.tpo.name?.charAt(0) ||
+                      project.properties.tpo.slug?.charAt(0).toUpperCase() ||
+                      ""}
                   </div>
                 )}
                 {project.properties.country && (


### PR DESCRIPTION
Fixes client side error due to null value received for tpo name in the `/projects` response