### PR TITLE
Disable unsupported payment currencies

### DIFF
--- a/src/Common/Types/index.tsx
+++ b/src/Common/Types/index.tsx
@@ -193,3 +193,18 @@ export interface Recurrency {
   methods?: string[] | null;
   frequencies?: string[] | null;
 }
+
+export interface Country {
+  countryName: string;
+  countryCode: string;
+  currencyName: string;
+  currencyCode: string;
+  currencyCountryFlag: string;
+  languageCode: string;
+}
+
+export type CountryProperty = keyof Country;
+
+export interface CurrencyList {
+  [key: string]: string;
+}

--- a/src/Donations/Micros/SelectCurrencyModal.tsx
+++ b/src/Donations/Micros/SelectCurrencyModal.tsx
@@ -4,7 +4,7 @@ import FormControl from "@material-ui/core/FormControl";
 import Modal from "@material-ui/core/Modal";
 import { makeStyles, withStyles } from "@material-ui/core/styles";
 import Autocomplete from "@material-ui/lab/Autocomplete";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useContext, useEffect, useState } from "react";
 import { useTranslation } from "next-i18next";
 import { ThemeContext } from "../../../styles/themeContext";
 import MaterialTextField from "../../Common/InputTypes/MaterialTextField";
@@ -26,15 +26,15 @@ export default function SelectCurrencyModal({
   handleModalClose,
 }: SelectCurrencyModalProps): ReactElement | null {
   const { setcountry, country, currency, enabledCurrencies } =
-    React.useContext(QueryParamContext);
+    useContext(QueryParamContext);
 
   const { t, ready } = useTranslation(["common", "country"]);
 
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
 
-  const [importantList, setImportantList] = React.useState<Array<string>>([]);
+  const [importantList, setImportantList] = useState<Array<string>>([]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // sets two default country as important country which is US(United States) and DE (Germany)
     const impCountryList = ["US", "DE"];
     // if the selected country is other than US and DE then add that country to important country list
@@ -117,7 +117,7 @@ function MapCurrency({
 }: MapCurrencyProps) {
   const { t, i18n, ready } = useTranslation(["country"]);
 
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
 
   const useStylesAutoComplete = makeStyles({
     paper: {

--- a/src/Donations/Micros/SelectCurrencyModal.tsx
+++ b/src/Donations/Micros/SelectCurrencyModal.tsx
@@ -4,7 +4,7 @@ import FormControl from "@material-ui/core/FormControl";
 import Modal from "@material-ui/core/Modal";
 import { makeStyles, withStyles } from "@material-ui/core/styles";
 import Autocomplete from "@material-ui/lab/Autocomplete";
-import React from "react";
+import React, { ReactElement } from "react";
 import { useTranslation } from "next-i18next";
 import { ThemeContext } from "../../../styles/themeContext";
 import MaterialTextField from "../../Common/InputTypes/MaterialTextField";
@@ -14,9 +14,17 @@ import {
   sortCountriesByTranslation,
 } from "../../Utils/countryUtils";
 import themeProperties from "../../../styles/themeProperties";
-export default function TransitionsModal(props: any) {
-  const { openModal, handleModalClose } = props;
+import { Country, CurrencyList } from "src/Common/Types";
 
+interface SelectCurrencyModalProps {
+  openModal: boolean;
+  handleModalClose: () => void;
+}
+
+export default function SelectCurrencyModal({
+  openModal,
+  handleModalClose,
+}: SelectCurrencyModalProps): ReactElement | null {
   const { setcountry, country, currency, enabledCurrencies } =
     React.useContext(QueryParamContext);
 
@@ -24,7 +32,7 @@ export default function TransitionsModal(props: any) {
 
   const { theme } = React.useContext(ThemeContext);
 
-  const [importantList, setImportantList] = React.useState<Array<Object>>([]);
+  const [importantList, setImportantList] = React.useState<Array<string>>([]);
 
   React.useEffect(() => {
     // sets two default country as important country which is US(United States) and DE (Germany)
@@ -60,7 +68,7 @@ export default function TransitionsModal(props: any) {
                 enabledCurrencies={enabledCurrencies}
                 priorityCountries={importantList}
                 value={country}
-                handleChange={(value) => {
+                handleChange={(value: Country) => {
                   setcountry(value.countryCode);
                   // setcurrency
                   localStorage.setItem("countryCode", value.countryCode);
@@ -81,12 +89,6 @@ const FormControlNew = withStyles({
   },
 })(FormControl);
 
-interface CountryType {
-  countryCode: string;
-  label: string;
-  currencyCode: string;
-}
-
 // ISO 3166-1 alpha-2
 // ⚠️ No support for IE 11
 function countryToFlag(isoCode: string) {
@@ -99,11 +101,21 @@ function countryToFlag(isoCode: string) {
     : isoCode;
 }
 
-// Maps the radio buttons for currency
-function MapCurrency(props: any) {
-  const { t, i18n, ready } = useTranslation(["country"]);
+interface MapCurrencyProps {
+  enabledCurrencies: CurrencyList;
+  priorityCountries: string[];
+  value: string;
+  handleChange: (value: Country) => void;
+}
 
-  const { enabledCurrencies, priorityCountries, value, handleChange } = props;
+// Shows autocomplete options for currency
+function MapCurrency({
+  enabledCurrencies,
+  priorityCountries,
+  value,
+  handleChange,
+}: MapCurrencyProps) {
+  const { t, i18n, ready } = useTranslation(["country"]);
 
   const { theme } = React.useContext(ThemeContext);
 
@@ -159,7 +171,7 @@ function MapCurrency(props: any) {
           <Autocomplete
             data-test-id="country-select"
             style={{ width: "100%" }}
-            options={sortedCountriesData as CountryType[]}
+            options={sortedCountriesData as Country[]}
             classes={{
               option: classes.option,
               paper: classes.paper,
@@ -179,16 +191,14 @@ function MapCurrency(props: any) {
                 } `}
               </>
             )}
-            onChange={(event: any, newValue: CountryType | null) => {
+            onChange={(_event, newValue: Country | null) => {
               if (newValue) {
                 handleChange(newValue);
               }
             }}
-            defaultValue={value.label}
             renderInput={(params) => (
               <MaterialTextField
                 {...params}
-                label={props.label}
                 variant="outlined"
                 inputProps={{
                   ...params.inputProps,

--- a/src/Donations/Micros/SelectCurrencyModal.tsx
+++ b/src/Donations/Micros/SelectCurrencyModal.tsx
@@ -17,7 +17,8 @@ import themeProperties from "../../../styles/themeProperties";
 export default function TransitionsModal(props: any) {
   const { openModal, handleModalClose } = props;
 
-  const { setcountry, country, currency } = React.useContext(QueryParamContext);
+  const { setcountry, country, currency, enabledCurrencies } =
+    React.useContext(QueryParamContext);
 
   const { t, ready } = useTranslation(["common", "country"]);
 
@@ -56,6 +57,7 @@ export default function TransitionsModal(props: any) {
               <p className={"select-language-title"}>{t("selectCurrency")}</p>
               <MapCurrency
                 // this is selectedValue, country wala object
+                enabledCurrencies={enabledCurrencies}
                 priorityCountries={importantList}
                 value={country}
                 handleChange={(value) => {
@@ -101,7 +103,7 @@ function countryToFlag(isoCode: string) {
 function MapCurrency(props: any) {
   const { t, i18n, ready } = useTranslation(["country"]);
 
-  const { priorityCountries, value, handleChange } = props;
+  const { enabledCurrencies, priorityCountries, value, handleChange } = props;
 
   const { theme } = React.useContext(ThemeContext);
 
@@ -140,7 +142,12 @@ function MapCurrency(props: any) {
   const classes = useStylesAutoComplete();
 
   const sortedCountriesData = ready
-    ? sortCountriesByTranslation(t, i18n.language, priorityCountries)
+    ? sortCountriesByTranslation(
+        t,
+        i18n.language,
+        priorityCountries,
+        enabledCurrencies
+      )
     : {};
 
   const selectedCountry = getCountryDataBy("countryCode", value);

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -7,7 +7,7 @@ import { ThemeContext } from "../../styles/themeContext";
 import countriesData from "../Utils/countriesData.json";
 import { setCountryCode } from "src/Utils/setCountryCode";
 import { THANK_YOU } from "src/Utils/donationStepConstants";
-import { PaymentSetupProps } from "src/Common/Types";
+import { PaymentSetupProps, CurrencyList } from "src/Common/Types";
 import { useAuth0 } from "@auth0/auth0-react";
 import { validateToken } from "../Utils/tokenActions";
 import allLocales from "../../public/static/localeList.json";
@@ -26,7 +26,7 @@ export const QueryParamContext = React.createContext({
   currency: "",
   setcurrency: (value: "") => {},
   enabledCurrencies: {},
-  setEnabledCurrencies: (value: {}) => {},
+  setEnabledCurrencies: (value: CurrencyList) => {},
   donationStep: null,
   setdonationStep: (value: number) => {},
   projectDetails: null,
@@ -172,9 +172,8 @@ export default function QueryParamProvider({ children }: any) {
 
   const [country, setcountry] = useState<string | string[]>("");
   const [currency, setcurrency] = useState("");
-  const [enabledCurrencies, setEnabledCurrencies] = useState<null | Object>(
-    null
-  );
+  const [enabledCurrencies, setEnabledCurrencies] =
+    useState<null | CurrencyList>(null);
   const [callbackUrl, setcallbackUrl] = useState("");
   const [taxIdentificationAvail, setTaxIdentificationAvail] = useState(false);
   const [callbackMethod, setCallbackMethod] = useState("");

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -25,6 +25,8 @@ export const QueryParamContext = React.createContext({
   setpaymentSetup: ({}) => {},
   currency: "",
   setcurrency: (value: "") => {},
+  enabledCurrencies: {},
+  setEnabledCurrencies: (value: {}) => {},
   donationStep: null,
   setdonationStep: (value: number) => {},
   projectDetails: null,
@@ -170,6 +172,7 @@ export default function QueryParamProvider({ children }: any) {
 
   const [country, setcountry] = useState<string | string[]>("");
   const [currency, setcurrency] = useState("");
+  const [enabledCurrencies, setEnabledCurrencies] = useState({});
   const [callbackUrl, setcallbackUrl] = useState("");
   const [taxIdentificationAvail, setTaxIdentificationAvail] = useState(false);
   const [callbackMethod, setCallbackMethod] = useState("");
@@ -211,6 +214,19 @@ export default function QueryParamProvider({ children }: any) {
 
   const [donation, setdonation] = React.useState(null);
   const [paymentRequest, setPaymentRequest] = React.useState(null);
+
+  const loadEnabledCurrencies = async () => {
+    const requestParams = {
+      url: `/public/v1.1/en/currencies`,
+      setshowErrorCard,
+    };
+    const response: any = await apiRequest(requestParams);
+    setEnabledCurrencies(response.data.currency_names);
+  };
+
+  React.useEffect(() => {
+    loadEnabledCurrencies();
+  }, []);
 
   React.useEffect(() => {
     if (paymentError) {
@@ -575,6 +591,8 @@ export default function QueryParamProvider({ children }: any) {
         paymentSetup,
         currency,
         setcurrency,
+        enabledCurrencies,
+        setEnabledCurrencies,
         donationStep,
         setdonationStep,
         projectDetails,

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -231,6 +231,7 @@ export default function QueryParamProvider({ children }: any) {
       setEnabledCurrencies(response.data.currency_names);
     } catch (err) {
       console.log(err);
+      setEnabledCurrencies(null);
     }
   };
 
@@ -239,6 +240,16 @@ export default function QueryParamProvider({ children }: any) {
     if (!enabledCurrencies && donationStep !== null && donationStep <= 1)
       loadEnabledCurrencies();
   }, [donationStep, enabledCurrencies]);
+
+  useEffect(() => {
+    if (
+      currency &&
+      enabledCurrencies &&
+      enabledCurrencies[currency] === undefined
+    ) {
+      setCountryCode({ setcountry, setcurrency, country: "DE" });
+    }
+  }, [currency, enabledCurrencies]);
 
   useEffect(() => {
     if (paymentError) {

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -1,5 +1,12 @@
 import { useRouter } from "next/dist/client/router";
-import React, { useState, ReactElement } from "react";
+import React, {
+  useState,
+  ReactElement,
+  createContext,
+  useEffect,
+  useContext,
+  useCallback,
+} from "react";
 import { apiRequest } from "../Utils/api";
 import { useTranslation } from "next-i18next";
 import { getRandomProjects } from "../Utils/projects/filterProjects";
@@ -12,7 +19,7 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { validateToken } from "../Utils/tokenActions";
 import allLocales from "../../public/static/localeList.json";
 
-export const QueryParamContext = React.createContext({
+export const QueryParamContext = createContext({
   isGift: false,
   setisGift: (value: boolean) => {},
   giftDetails: {},
@@ -135,17 +142,17 @@ export default function QueryParamProvider({ children }: any) {
   const [tenant, settenant] = useState("ten_I9TW3ncG");
 
   // for tax deduction part
-  const [isTaxDeductible, setIsTaxDeductible] = React.useState(false);
+  const [isTaxDeductible, setIsTaxDeductible] = useState(false);
   const [allowTaxDeductionChange, setallowTaxDeductionChange] = useState(true);
 
-  const [isDirectDonation, setisDirectDonation] = React.useState(false);
+  const [isDirectDonation, setisDirectDonation] = useState(false);
 
   const [donationUid, setDonationUid] = useState(null);
 
   const [isPaymentOptionsLoading, setIsPaymentOptionsLoading] =
-    React.useState<boolean>(false);
+    useState<boolean>(false);
 
-  const [paymentType, setPaymentType] = React.useState("");
+  const [paymentType, setPaymentType] = useState("");
 
   const [quantity, setquantity] = useState(50);
   const [frequency, setfrequency] = useState<null | string>("once");
@@ -158,7 +165,7 @@ export default function QueryParamProvider({ children }: any) {
     type: "",
   });
 
-  const [contactDetails, setContactDetails] = React.useState({
+  const [contactDetails, setContactDetails] = useState({
     firstname: "",
     lastname: "",
     tin: "",
@@ -187,20 +194,18 @@ export default function QueryParamProvider({ children }: any) {
 
   const [hideTaxDeduction, sethideTaxDeduction] = useState(false);
 
-  const [profile, setprofile] = React.useState<null | Object>(null);
-  const [amount, setAmount] = React.useState<null | number>(null);
+  const [profile, setprofile] = useState<null | Object>(null);
+  const [amount, setAmount] = useState<null | number>(null);
   const [retainQuantityValue, setRetainQuantityValue] =
-    React.useState<boolean>(false);
+    useState<boolean>(false);
   // Language = locale => Can be received from the URL, can also be set by the user, can be extracted from browser language
-  const [isSignedUp, setIsSignedUp] = React.useState<boolean>(false);
+  const [isSignedUp, setIsSignedUp] = useState<boolean>(false);
 
-  const [hideLogin, setHideLogin] = React.useState<boolean>(false);
-  const [paymentError, setPaymentError] = React.useState("");
-  const [transferDetails, setTransferDetails] = React.useState<Object | null>(
-    null
-  );
-  const [projectName, setProjectName] = React.useState("");
-  const [projectDescription, setProjectDescription] = React.useState("");
+  const [hideLogin, setHideLogin] = useState<boolean>(false);
+  const [paymentError, setPaymentError] = useState("");
+  const [transferDetails, setTransferDetails] = useState<Object | null>(null);
+  const [projectName, setProjectName] = useState("");
+  const [projectDescription, setProjectDescription] = useState("");
 
   const [isPlanetCashActive, setIsPlanetCashActive] = useState(false);
 
@@ -213,8 +218,8 @@ export default function QueryParamProvider({ children }: any) {
     email: "",
   });
 
-  const [donation, setdonation] = React.useState(null);
-  const [paymentRequest, setPaymentRequest] = React.useState(null);
+  const [donation, setdonation] = useState(null);
+  const [paymentRequest, setPaymentRequest] = useState(null);
 
   const loadEnabledCurrencies = async () => {
     try {
@@ -229,20 +234,20 @@ export default function QueryParamProvider({ children }: any) {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     // Enabled currencies are only needed on step 1, if not already populated
     if (!enabledCurrencies && donationStep !== null && donationStep <= 1)
       loadEnabledCurrencies();
   }, [donationStep, enabledCurrencies]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (paymentError) {
       router.replace({
         query: { ...router.query, step: THANK_YOU },
       });
     }
   }, [paymentError]);
-  React.useEffect(() => {
+  useEffect(() => {
     if (allLocales.some((locale) => locale.key === router.query.locale)) {
       setlanguage(router.query.locale);
     } else {
@@ -259,7 +264,7 @@ export default function QueryParamProvider({ children }: any) {
     }
   }, [router.query.locale]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (i18n && i18n.isInitialized) {
       i18n.changeLanguage(language);
       localStorage.setItem("language", language);
@@ -275,7 +280,7 @@ export default function QueryParamProvider({ children }: any) {
     // regex source https://tutorial.eyehunts.com/js/url-regex-validation-javascript-example-code/
     return !!pattern.test(url);
   }
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.query.callback_url) {
       if (testURL(router.query.callback_url)) {
         setcallbackUrl(router.query.callback_url);
@@ -283,13 +288,13 @@ export default function QueryParamProvider({ children }: any) {
     }
   }, [router.query.callback_url]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.query.callback_method) {
       setCallbackMethod(router.query.callback_method);
     }
   }, [router.query.callback_method]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (
       paymentSetup?.frequencies &&
       Object.keys(paymentSetup.frequencies).length === 2
@@ -325,7 +330,7 @@ export default function QueryParamProvider({ children }: any) {
     }
   }
 
-  const loadProfile = React.useCallback(async () => {
+  const loadProfile = useCallback(async () => {
     const token =
       queryToken || router.query.token || (await getAccessTokenSilently());
     try {
@@ -351,13 +356,13 @@ export default function QueryParamProvider({ children }: any) {
     setdonationStep(4);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!isLoading && isAuthenticated) {
       loadProfile();
     }
   }, [isLoading, isAuthenticated, loadProfile]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const regex = /^pcash_/;
     if (regex.test(router.query.to)) {
       router.push("/");
@@ -406,7 +411,7 @@ export default function QueryParamProvider({ children }: any) {
     router.query.token,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const regex = /^pcash_/;
     if (
       router.query.to &&
@@ -475,14 +480,14 @@ export default function QueryParamProvider({ children }: any) {
     }
   }
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.isReady) {
       loadConfig();
     }
   }, [router.isReady]);
 
   // Tree Count = treecount => Received from the URL
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.query.units) {
       // Do not allow 0 or negative numbers and string
       if (Number(router.query.units) > 0 && paymentSetup.unitCost) {
@@ -492,20 +497,20 @@ export default function QueryParamProvider({ children }: any) {
     setRetainQuantityValue(false);
   }, [router.query.units, paymentSetup]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.query.method) {
       // TODO => only allow the ones which we use, add an array and check if it exists in that array
       setPaymentType(router.query.method);
     }
   }, [router.query.method]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (router.query.redirect_status) {
       setredirectstatus(router.query.redirect_status);
     }
   }, [router.query.redirect_status]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setshouldCreateDonation(true);
   }, [
     paymentSetup,
@@ -524,8 +529,8 @@ export default function QueryParamProvider({ children }: any) {
     isTaxDeductible,
   ]);
 
-  const [showErrorCard, setshowErrorCard] = React.useState(false);
-  React.useEffect(() => {
+  const [showErrorCard, setshowErrorCard] = useState(false);
+  useEffect(() => {
     if (router.query.error) {
       if (
         router.query.error_description === "401" &&
@@ -698,9 +703,9 @@ function ErrorCard({
 }: CardProps): ReactElement {
   const { t, ready } = useTranslation(["common"]);
 
-  const { theme } = React.useContext(ThemeContext);
+  const { theme } = useContext(ThemeContext);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (showErrorCard) {
       setTimeout(() => {
         setShowErrorCard(false);
@@ -718,5 +723,5 @@ function ErrorCard({
 }
 
 export function useTheme() {
-  return React.useContext(QueryParamContext);
+  return useContext(QueryParamContext);
 }

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -224,11 +224,11 @@ export default function QueryParamProvider({ children }: any) {
   const loadEnabledCurrencies = async () => {
     try {
       const requestParams = {
-        url: `/public/v1.1/en/currencies`,
+        url: `/app/currencies`,
         setshowErrorCard,
       };
       const response: any = await apiRequest(requestParams);
-      setEnabledCurrencies(response.data.currency_names);
+      setEnabledCurrencies(response.data);
     } catch (err) {
       console.log(err);
       setEnabledCurrencies(null);

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -217,12 +217,16 @@ export default function QueryParamProvider({ children }: any) {
   const [paymentRequest, setPaymentRequest] = React.useState(null);
 
   const loadEnabledCurrencies = async () => {
-    const requestParams = {
-      url: `/public/v1.1/en/currencies`,
-      setshowErrorCard,
-    };
-    const response: any = await apiRequest(requestParams);
-    setEnabledCurrencies(response.data.currency_names);
+    try {
+      const requestParams = {
+        url: `/public/v1.1/en/currencies`,
+        setshowErrorCard,
+      };
+      const response: any = await apiRequest(requestParams);
+      setEnabledCurrencies(response.data.currency_names);
+    } catch (err) {
+      console.log(err);
+    }
   };
 
   React.useEffect(() => {

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -172,7 +172,9 @@ export default function QueryParamProvider({ children }: any) {
 
   const [country, setcountry] = useState<string | string[]>("");
   const [currency, setcurrency] = useState("");
-  const [enabledCurrencies, setEnabledCurrencies] = useState({});
+  const [enabledCurrencies, setEnabledCurrencies] = useState<null | Object>(
+    null
+  );
   const [callbackUrl, setcallbackUrl] = useState("");
   const [taxIdentificationAvail, setTaxIdentificationAvail] = useState(false);
   const [callbackMethod, setCallbackMethod] = useState("");
@@ -225,8 +227,10 @@ export default function QueryParamProvider({ children }: any) {
   };
 
   React.useEffect(() => {
-    loadEnabledCurrencies();
-  }, []);
+    // Enabled currencies are only needed on step 1, if not already populated
+    if (!enabledCurrencies && donationStep !== null && donationStep <= 1)
+      loadEnabledCurrencies();
+  }, [donationStep, enabledCurrencies]);
 
   React.useEffect(() => {
     if (paymentError) {

--- a/src/Utils/countriesData.json
+++ b/src/Utils/countriesData.json
@@ -1958,13 +1958,5 @@
     "currencyCode": "RSD",
     "currencyCountryFlag": "RS",
     "languageCode": "en"
-  },
-  {
-    "countryName": "US Armed Forces",
-    "countryCode": "USAF",
-    "currencyName": "US Dollar",
-    "currencyCode": "USD",
-    "currencyCountryFlag": "US",
-    "languageCode": "en"
   }
 ]

--- a/src/Utils/countryUtils.ts
+++ b/src/Utils/countryUtils.ts
@@ -1,5 +1,7 @@
 import countriesData from "./countriesData.json";
 
+type CountriesArray = typeof countriesData;
+
 const sortedCountries = {};
 
 /**
@@ -42,21 +44,40 @@ export function sortCountriesData(sortBy) {
 }
 
 /**
+ * Filters countries array and returns countries with enabled currencies (for payment)
+ * @param countriesData
+ * @param enabledCurrencies
+ * @returns {CountriesArray} Countries with currencies enabled for payment
+ */
+function filterByEnabledCurrencies(
+  countriesData: CountriesArray,
+  enabledCurrencies
+) {
+  return countriesData.filter((country) => {
+    return enabledCurrencies[country.currencyCode] !== undefined;
+  });
+}
+
+/**
  * Sorts the countries array for the translated country name
  * @param {Function} t - translation function
  * @param {String} language - language to get country names for
  * @param {Array} priorityCountries - country code to always show first in given order
  */
-export function sortCountriesByTranslation(t, language, priorityCountryCodes) {
+export function sortCountriesByTranslation(
+  t,
+  language,
+  priorityCountryCodes,
+  enabledCurrencies
+) {
   const key = `${language}.${priorityCountryCodes}`;
   if (!sortedCountries[key]) {
     const priorityCountries = [];
     // filter priority countries from list
-    const filteredCountries = countriesData.filter(function (
-      value,
-      index,
-      arr
-    ) {
+    const filteredCountries = filterByEnabledCurrencies(
+      countriesData,
+      enabledCurrencies
+    ).filter(function (value, index, arr) {
       if (priorityCountryCodes?.includes(value.countryCode)) {
         priorityCountries.push(value);
         return false;

--- a/src/Utils/countryUtils.ts
+++ b/src/Utils/countryUtils.ts
@@ -1,8 +1,8 @@
 import countriesData from "./countriesData.json";
+import { Country, CountryProperty, CurrencyList } from "src/Common/Types";
+import { TFunction } from "react-i18next";
 
-type CountriesArray = typeof countriesData;
-
-const sortedCountries = {};
+const sortedCountries: { [key: string]: Country[] } = {};
 
 /**
  * * Returns country details by searching country data json file and options
@@ -15,7 +15,10 @@ const sortedCountries = {};
  *  - {countryCode, countryName, currencyName, currencyCode, currencyCountryFlag}
  */
 // eslint-disable-next-line consistent-return
-export function getCountryDataBy(key, value) {
+export function getCountryDataBy(
+  key: CountryProperty,
+  value: string
+): Country | undefined {
   // Finds required country data from the country data array and returns the
   // matched country result
   for (let i = 0; i < countriesData.length; i += 1) {
@@ -30,7 +33,7 @@ export function getCountryDataBy(key, value) {
  * @param {String} sortBy - can have values
  *    countryName, currencyName, currencyCode, currencyCountryFlag
  */
-export function sortCountriesData(sortBy) {
+export function sortCountriesData(sortBy: CountryProperty): Country[] {
   // returns a sorted array which is sorted by passed value
   return countriesData.sort((a, b) => {
     if (a[sortBy] > b[sortBy]) {
@@ -50,8 +53,8 @@ export function sortCountriesData(sortBy) {
  * @returns {CountriesArray} Countries with currencies enabled for payment
  */
 function filterByEnabledCurrencies(
-  countriesData: CountriesArray,
-  enabledCurrencies
+  countriesData: Country[],
+  enabledCurrencies: CurrencyList
 ) {
   return countriesData.filter((country) => {
     return enabledCurrencies[country.currencyCode] !== undefined;
@@ -63,21 +66,22 @@ function filterByEnabledCurrencies(
  * @param {Function} t - translation function
  * @param {String} language - language to get country names for
  * @param {Array} priorityCountries - country code to always show first in given order
+ * @param {CurrencyList} enabledCurrencies - object containing enabled currencies
  */
 export function sortCountriesByTranslation(
-  t,
-  language,
-  priorityCountryCodes,
-  enabledCurrencies
-) {
+  t: TFunction,
+  language: string,
+  priorityCountryCodes: string[],
+  enabledCurrencies: CurrencyList
+): Country[] {
   const key = `${language}.${priorityCountryCodes}`;
   if (!sortedCountries[key]) {
-    const priorityCountries = [];
+    const priorityCountries: Country[] = [];
     // filter priority countries from list
     const filteredCountries = filterByEnabledCurrencies(
       countriesData,
       enabledCurrencies
-    ).filter(function (value, index, arr) {
+    ).filter(function (value) {
       if (priorityCountryCodes?.includes(value.countryCode)) {
         priorityCountries.push(value);
         return false;

--- a/src/Utils/countryUtils.ts
+++ b/src/Utils/countryUtils.ts
@@ -1,6 +1,6 @@
 import countriesData from "./countriesData.json";
 
-const sortedCountries = [];
+const sortedCountries = {};
 
 /**
  * * Returns country details by searching country data json file and options


### PR DESCRIPTION
1. Fixes https://github.com/Plant-for-the-Planet-org/planet-webapp/issues/773
2. Fetches supported currencies by API (~~Note - API will be replaced by a new API with a similar response format, to be updated once the API is available~~) and filters list of currencies available while making a donation (in the donate step), removing unsupported currencies from the currency selector.
3. Adds fallback to Euros if an invalid currency is somehow selected (e.g. if you provide ?country=AQ in the URL).  
4. Also includes some code cleanup.
