### PR TITLE
Update Croatian currency to Euros

### DIFF
--- a/src/Utils/countriesData.json
+++ b/src/Utils/countriesData.json
@@ -890,8 +890,8 @@
   {
     "countryName": "Croatia (Hrvatska)",
     "countryCode": "HR",
-    "currencyName": "Croatian Dinar",
-    "currencyCode": "HRK",
+    "currencyName": "Euros",
+    "currencyCode": "EUR",
     "currencyCountryFlag": "HR",
     "languageCode": "en"
   },


### PR DESCRIPTION
Update Croatian currency to Euros. To be released on January 1, 2023 when Croatia joins the Eurozone and the Croatian Kuna (HRK) is deprecated in favor of the Euro.