### PR TITLE
fix: add paypal error message with translations

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -79,6 +79,7 @@
   "thankyouHeaderText": "Wir sind auf dem Weg zu einer \n <h1>Billion Bäume</h1>.",
   "donationFailed": "Spende fehlgeschlagen",
   "donationFailedMessage": "Beim Abschluss deiner Zahlung ist etwas schief gelaufen. Wenn du weiterhin Probleme hast, kontaktiere uns bitte unter support@plant-for-the-planet.org.",
+  "paypalPaymentError": "Leider haben wir bei PayPal Zahlungen aktuell vereinzelt Probleme. Bitte versuchen Sie es erneut mit einer anderen Zahlart. Vielen Dank für Ihre Unterstützung und Ihr Verständnis. Wir arbeiten an der Problemlösung.",
   "donationPending": "Abschließen deiner Spende",
   "donationPendingMessage": "Wir warten derzeit auf die Bestätigung von deiner Bank. Dies kann einige Zeit dauern, daher kannst du diese Seite auch schließen. Wir werden dir den Beleg in Kürze per E-Mail zusenden.",
   "transactionId": "Transaktions-ID",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -79,6 +79,7 @@
   "thankyouHeaderText": "We're on the road to a \n <h1>Trillion Trees</h1>.",
   "donationFailed": "Donation Failed",
   "donationFailedMessage": "Something went wrong while completing your payment. If you continue having issues please reach out to us at support@plant-for-the-planet.org",
+  "paypalPaymentError": "Unfortunately, we are currently experiencing isolated problems with PayPal payments. Please try again with another payment method. Thank you for your support and understanding. We are working on solving the problem.",
   "donationPending": "Completing your donation",
   "donationPendingMessage": "We are currently waiting for the confirmation from your bank. This might take some time so, please feel free to close this page. We’ll send your receipt via email shortly.",
   "transactionId": "Transaction ID",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -66,6 +66,7 @@
   "thankyouHeaderText": "Estamos en el camino hacia una \n <h1>Trillón de árboles</h1>",
   "donationFailed": "Donación fallida",
   "donationFailedMessage": "Algo ha ido mal al completar el pago. Si sigue teniendo problemas, póngase en contacto con nosotros en support@plant-for-the-planet.org",
+  "paypalPaymentError": "Lamentablemente, estamos experimentando problemas con los pagos de PayPal. Por favor, inténtelo de nuevo con otro método de pago. Gracias por su apoyo y comprensión. Estamos trabajando en una solución al problema.",
   "donationPending": "Completar su donación",
   "donationPendingMessage": "Actualmente estamos esperando la confirmación de su banco. Esto puede llevar algún tiempo, así que no dude en cerrar esta página. En breve le enviaremos su recibo por correo electrónico.",
   "transactionId": "Ref. de la donación",

--- a/src/Donations/PaymentMethods/NewPaypal.tsx
+++ b/src/Donations/PaymentMethods/NewPaypal.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from "react";
+import { useTranslation, UseTranslation } from "next-i18next";
 import {
   PayPalScriptProvider,
   PayPalButtons,
@@ -26,6 +27,7 @@ function NewPaypal({
   payDonationFunction,
   setPaymentError,
 }: Props): ReactElement {
+  const { t } = useTranslation("common");
   const initialOptions = {
     "client-id": paymentSetup?.gateways.paypal.authorization.client_id,
     "enable-funding": "venmo",
@@ -66,9 +68,9 @@ function NewPaypal({
   }
 
   const onError = (data) => {
-    setPaymentError(`Your order failed due to some error.`);
+    setPaymentError(t("paypalPaymentError"));
 
-    // This function shows a transaction success message to your buyer.
+    // This function shows a transaction error message to your buyer.
     data = {
       ...data,
       type: "sdk",


### PR DESCRIPTION
Adds an error message for paypal payment errors, guiding user to use other payment methods