### PR TITLE
Release: Update Croatian currency to Euro (1st Jan 2023)

### DIFF
--- a/src/Utils/countriesData.json
+++ b/src/Utils/countriesData.json
@@ -890,8 +890,8 @@
   {
     "countryName": "Croatia (Hrvatska)",
     "countryCode": "HR",
-    "currencyName": "Croatian Dinar",
-    "currencyCode": "HRK",
+    "currencyName": "Euros",
+    "currencyCode": "EUR",
     "currencyCountryFlag": "HR",
     "languageCode": "en"
   },


### PR DESCRIPTION
Updates Croatian currency to Euros to prepare for deprecation of HRK when Croatia joins the Eurozone 