### PR TITLE
Upgrade react hook form to v7 (for next 13 update)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "playwright-core": "^1.25.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-hook-form": "6.14.2",
+        "react-hook-form": "^7.43.1",
         "sass": "^1.35.1",
         "styled-jsx": "^5.1.0",
         "uuid": "^8.3.2"
@@ -7213,11 +7213,18 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.14.2.tgz",
-      "integrity": "sha512-GgDUuT3Yfhl1BOcMl862uAFbCixSomtm3CVlQQ1qVu9Tq5BN2uUIRUIXP8l2Gy99eLUrBqU9x4E7N+si9cnvaw==",
+      "version": "7.43.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.1.tgz",
+      "integrity": "sha512-+s3+s8LLytRMriwwuSqeLStVjRXFGxgjjx2jED7Z+wz1J/88vpxieRQGvJVvzrzVxshZ0BRuocFERb779m2kNg==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17"
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-i18next": {
@@ -13909,9 +13916,9 @@
       }
     },
     "react-hook-form": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.14.2.tgz",
-      "integrity": "sha512-GgDUuT3Yfhl1BOcMl862uAFbCixSomtm3CVlQQ1qVu9Tq5BN2uUIRUIXP8l2Gy99eLUrBqU9x4E7N+si9cnvaw==",
+      "version": "7.43.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.43.1.tgz",
+      "integrity": "sha512-+s3+s8LLytRMriwwuSqeLStVjRXFGxgjjx2jED7Z+wz1J/88vpxieRQGvJVvzrzVxshZ0BRuocFERb779m2kNg==",
       "requires": {}
     },
     "react-i18next": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "playwright-core": "^1.25.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-hook-form": "6.14.2",
+    "react-hook-form": "^7.43.1",
     "sass": "^1.35.1",
     "styled-jsx": "^5.1.0",
     "uuid": "^8.3.2"

--- a/src/Common/InputTypes/MaterialTextField.tsx
+++ b/src/Common/InputTypes/MaterialTextField.tsx
@@ -46,7 +46,7 @@ const MaterialTextField = styled(TextField)({
   "& .MuiOutlinedInput-input": {
     padding: "14px",
   },
-  "& .MuiOutlinedInput-multiline": {
+  "& .MuiInputBase-multiline": {
     padding: "0px",
   },
   '& .MuiAutocomplete-inputRoot[class*="MuiOutlinedInput-root"]': {

--- a/src/Donations/Components/ContactsForm.tsx
+++ b/src/Donations/Components/ContactsForm.tsx
@@ -60,16 +60,15 @@ function ContactsForm(): ReactElement {
   }, [contactDetails]);
 
   const {
-    register,
-    errors,
     handleSubmit,
     control,
     reset,
     getValues,
     setValue,
+    formState: { errors },
   } = useForm<ContactDetails>({
     mode: "all",
-    defaultValues: {},
+    defaultValues: contactDetails,
   });
 
   React.useEffect(() => {
@@ -194,16 +193,19 @@ function ContactsForm(): ReactElement {
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="d-flex row">
             <div className={"form-field mt-20 flex-1"}>
-              <MaterialTextField
-                inputRef={register({
-                  required: true,
-                  minLength: 1,
-                })}
-                label={t("firstName")}
-                variant="outlined"
+              <Controller
                 name="firstname"
-                defaultValue={contactDetails.firstname}
-                data-test-id="test-firstName"
+                control={control}
+                rules={{ required: true, minLength: 1 }}
+                render={({ field: { onChange, value } }) => (
+                  <MaterialTextField
+                    onChange={onChange}
+                    value={value}
+                    label={t("firstName")}
+                    variant="outlined"
+                    data-test-id="test-firstName"
+                  />
+                )}
               />
               {errors.firstname && errors.firstname.type === "required" && (
                 <span className={"form-errors"}>{t("firstNameRequired")}</span>
@@ -216,13 +218,19 @@ function ContactsForm(): ReactElement {
             </div>
             <div style={{ width: "20px" }} />
             <div className={"form-field mt-20 flex-1"}>
-              <MaterialTextField
-                inputRef={register({ required: true, minLength: 1 })}
-                label={t("lastName")}
-                variant="outlined"
+              <Controller
                 name="lastname"
-                defaultValue={contactDetails.lastname}
-                data-test-id="test-lastName"
+                control={control}
+                rules={{ required: true, minLength: 1 }}
+                render={({ field: { onChange, value } }) => (
+                  <MaterialTextField
+                    onChange={onChange}
+                    value={value}
+                    label={t("lastName")}
+                    variant="outlined"
+                    data-test-id="test-lastName"
+                  />
+                )}
               />
               {errors.lastname && errors.lastname.type === "required" && (
                 <span className={"form-errors"}>{t("lastNameRequired")}</span>
@@ -236,23 +244,24 @@ function ContactsForm(): ReactElement {
           </div>
 
           <div className={"form-field mt-30"}>
-            <MaterialTextField
-              inputRef={register({
+            <Controller
+              name="email"
+              control={control}
+              rules={{
                 required: true,
                 pattern:
                   /^([a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)$/i,
-                // validate: (input) => {
-                //   return isAuthenticated || isSignedUp
-                //     ? true
-                //     : user.email === input;
-                // },
-              })}
-              label={t("email")}
-              variant="outlined"
-              name="email"
-              defaultValue={contactDetails.email}
-              data-test-id="test-email"
-              disabled={isAuthenticated}
+              }}
+              render={({ field: { onChange, value } }) => (
+                <MaterialTextField
+                  onChange={onChange}
+                  value={value}
+                  label={t("email")}
+                  variant="outlined"
+                  data-test-id="test-email"
+                  disabled={isAuthenticated}
+                />
+              )}
             />
             {errors.email && errors.email.type !== "validate" && (
               <span className={"form-errors"}>{t("emailRequired")}</span>
@@ -263,17 +272,26 @@ function ContactsForm(): ReactElement {
           </div>
 
           <div className={"form-field mt-30"} style={{ position: "relative" }}>
-            <MaterialTextField
-              inputRef={register({ required: true })}
-              label={t("address")}
-              variant="outlined"
+            <Controller
               name="address"
-              defaultValue={contactDetails.address}
-              data-test-id="test-address"
-              onChange={(event) => {
-                suggestAddress(event.target.value);
-              }}
-              onBlur={() => setaddressSugggestions([])}
+              control={control}
+              rules={{ required: true }}
+              render={({ field: { onChange, onBlur, value } }) => (
+                <MaterialTextField
+                  onChange={(event) => {
+                    suggestAddress(event.target.value);
+                    onChange(event);
+                  }}
+                  value={value}
+                  label={t("address")}
+                  variant="outlined"
+                  data-test-id="test-address"
+                  onBlur={() => {
+                    setaddressSugggestions([]);
+                    onBlur();
+                  }}
+                />
+              )}
             />
             {addressSugggestions
               ? addressSugggestions.length > 0 && (
@@ -301,13 +319,21 @@ function ContactsForm(): ReactElement {
 
           <div className={"d-flex row"}>
             <div className={"form-field mt-30 flex-1"}>
-              <MaterialTextField
-                inputRef={register({ required: true })}
-                label={t("city")}
-                variant="outlined"
+              <Controller
                 name="city"
-                defaultValue={contactDetails.city}
-                data-test-id="test-city"
+                control={control}
+                rules={{
+                  required: true,
+                }}
+                render={({ field: { onChange, value } }) => (
+                  <MaterialTextField
+                    onChange={onChange}
+                    value={value}
+                    label={t("city")}
+                    variant="outlined"
+                    data-test-id="test-city"
+                  />
+                )}
               />
               {errors.city && (
                 <span className={"form-errors"}>{t("cityRequired")}</span>
@@ -316,16 +342,22 @@ function ContactsForm(): ReactElement {
             <div style={{ width: "20px" }} />
             <div className={"form-field mt-30 flex-1"}>
               {true && (
-                <MaterialTextField
-                  inputRef={register({
+                <Controller
+                  name="zipCode"
+                  control={control}
+                  rules={{
                     required: true,
                     pattern: postalRegex,
-                  })}
-                  label={t("zipCode")}
-                  variant="outlined"
-                  name="zipCode"
-                  defaultValue={contactDetails.zipCode}
-                  data-test-id="test-zipCode"
+                  }}
+                  render={({ field: { onChange, value } }) => (
+                    <MaterialTextField
+                      onChange={onChange}
+                      value={value}
+                      label={t("zipCode")}
+                      variant="outlined"
+                      data-test-id="test-zipCode"
+                    />
+                  )}
                 />
               )}
               {errors.zipCode && (
@@ -349,7 +381,7 @@ function ContactsForm(): ReactElement {
               defaultValue={
                 contactDetails.country ? contactDetails.country : country
               }
-              render={({ value, ref }) => (
+              render={({ field: { value, ref } }) => (
                 <AutoCompleteCountry
                   inputRef={ref}
                   label={t("country")}
@@ -371,14 +403,18 @@ function ContactsForm(): ReactElement {
               data-test-id="taxIdentiication"
               id="taxIdentificationAvail"
             >
-              <MaterialTextField
-                inputRef={register({
-                  required: true,
-                })}
-                label={t("taxIdentificationNumber")}
-                variant="outlined"
+              <Controller
                 name="tin"
-                defaultValue={contactDetails.tin}
+                control={control}
+                rules={{ required: true }}
+                render={({ field: { onChange, value } }) => (
+                  <MaterialTextField
+                    onChange={onChange}
+                    value={value}
+                    label={t("taxIdentificationNumber")}
+                    variant="outlined"
+                  />
+                )}
               />
               {errors.tin && errors.tin.type !== "validate" && (
                 <span className={"form-errors"}>{t("tinRequired")}</span>
@@ -412,16 +448,19 @@ function ContactsForm(): ReactElement {
 
           {isCompany ? (
             <div className={"form-field mt-20"}>
-              <MaterialTextField
-                label={t("companyName")}
+              <Controller
                 name="companyname"
-                variant="outlined"
-                inputRef={
-                  isCompany
-                    ? register({ required: true })
-                    : register({ required: false })
-                }
-                defaultValue={contactDetails.companyname}
+                control={control}
+                rules={{ required: true }}
+                render={({ field: { onChange, value } }) => (
+                  <MaterialTextField
+                    onChange={onChange}
+                    value={value}
+                    label={t("companyName")}
+                    variant="outlined"
+                    data-test-id="test-companyname"
+                  />
+                )}
               />
               {errors.companyname && (
                 <span className={"form-errors"}>{t("companyRequired")}</span>

--- a/src/Donations/Micros/Authentication.tsx
+++ b/src/Donations/Micros/Authentication.tsx
@@ -82,6 +82,7 @@ function Authentication(): ReactElement {
             zipCode: profile.address.zipCode ? profile.address.zipCode : "",
             country: profile.address.country ? profile.address.country : "",
             companyname: "",
+            tin: "",
           };
           setContactDetails(newContactDetails);
         }

--- a/src/Donations/Micros/GiftForm.tsx
+++ b/src/Donations/Micros/GiftForm.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { useForm } from "react-hook-form";
+import { Controller, useForm } from "react-hook-form";
 import MaterialTextField from "../../Common/InputTypes/MaterialTextField";
 import InputAdornment from "@mui/material/InputAdornment";
 import { useTranslation } from "next-i18next";
@@ -28,7 +28,12 @@ export default function GiftForm(): ReactElement {
     message: giftDetails.message,
   };
 
-  const { register, errors, handleSubmit, reset } = useForm<GiftFormData>({
+  const {
+    handleSubmit,
+    reset,
+    control,
+    formState: { errors },
+  } = useForm<GiftFormData>({
     mode: "all",
     defaultValues: defaultDetails,
   });
@@ -85,19 +90,26 @@ export default function GiftForm(): ReactElement {
             className={`donations-gift-form ${isGift ? "" : "display-none"}`}
           >
             <div className={"form-field mt-20"}>
-              <MaterialTextField
-                name={"recipientName"}
-                label={t("recipientName")}
-                variant="outlined"
-                inputRef={register({ required: true })}
-                data-test-id="recipientName"
-                InputProps={{
-                  endAdornment: (
-                    <InputAdornment position="end">
-                      <GiftIcon />
-                    </InputAdornment>
-                  ),
-                }}
+              <Controller
+                name="recipientName"
+                control={control}
+                rules={{ required: true }}
+                render={({ field: { onChange, value } }) => (
+                  <MaterialTextField
+                    onChange={onChange}
+                    value={value}
+                    label={t("recipientName")}
+                    variant="outlined"
+                    data-test-id="recipientName"
+                    InputProps={{
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <GiftIcon />
+                        </InputAdornment>
+                      ),
+                    }}
+                  />
+                )}
               />
               {errors.recipientName && (
                 <span className={"form-errors"}>
@@ -118,32 +130,45 @@ export default function GiftForm(): ReactElement {
                       {t("removeRecipient")}
                     </button>
                   </div>
-
-                  <MaterialTextField
-                    name={"recipientEmail"}
-                    label={t("recipientEmail")}
-                    variant="outlined"
-                    inputRef={register({
+                  <Controller
+                    name="recipientEmail"
+                    control={control}
+                    rules={{
                       required: true,
                       pattern:
                         /^([a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)$/i,
-                    })}
-                    data-test-id="giftRecipient"
+                    }}
+                    render={({ field: { onChange, value } }) => (
+                      <MaterialTextField
+                        onChange={onChange}
+                        value={value}
+                        label={t("recipientEmail")}
+                        variant="outlined"
+                        data-test-id="giftRecipient"
+                      />
+                    )}
                   />
+
                   {errors.recipientEmail && (
                     <span className={"form-errors"}>{t("emailRequired")}</span>
                   )}
                 </div>
                 <div className={"form-field mt-30"}>
-                  <MaterialTextField
-                    multiline
-                    rows="3"
-                    rowsMax="4"
-                    label={t("giftMessage")}
-                    variant="outlined"
-                    name={"message"}
-                    inputRef={register()}
-                    data-test-id="giftMessage"
+                  <Controller
+                    name="message"
+                    control={control}
+                    render={({ field: { onChange, value } }) => (
+                      <MaterialTextField
+                        onChange={onChange}
+                        value={value}
+                        multiline
+                        minRows={3}
+                        maxRows={4}
+                        label={t("giftMessage")}
+                        variant="outlined"
+                        data-test-id="giftMessage"
+                      />
+                    )}
                   />
                 </div>
               </div>

--- a/src/Donations/Micros/OnBehalf.tsx
+++ b/src/Donations/Micros/OnBehalf.tsx
@@ -1,7 +1,7 @@
 import Grid from "@mui/material/Grid";
 import { useTranslation } from "next-i18next";
 import { FC, useContext, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, Controller } from "react-hook-form";
 import MaterialTextField from "src/Common/InputTypes/MaterialTextField";
 import ToggleSwitch from "src/Common/InputTypes/ToggleSwitch";
 import { QueryParamContext } from "src/Layout/QueryParamContext";
@@ -20,7 +20,12 @@ const OnBehalf: FC = () => {
     email: onBehalfDonor.email,
   };
 
-  const { register, errors, handleSubmit, reset } = useForm<OnBehalfDonor>({
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<OnBehalfDonor>({
     mode: "all",
     defaultValues,
   });
@@ -53,22 +58,36 @@ const OnBehalf: FC = () => {
         <div className="on-behalf-container-form-container mt-10">
           <Grid container spacing={3}>
             <Grid item xs={6}>
-              <MaterialTextField
+              <Controller
                 name="firstName"
-                inputRef={register({ required: true })}
-                label={t("firstName")}
-                variant="outlined"
+                control={control}
+                rules={{ required: true }}
+                render={({ field: { onChange, value } }) => (
+                  <MaterialTextField
+                    value={value}
+                    onChange={onChange}
+                    label={t("firstName")}
+                    variant="outlined"
+                  />
+                )}
               />
               {errors.firstName && (
                 <span className={"form-errors"}>{t("firstNameRequired")}</span>
               )}
             </Grid>
             <Grid item xs={6}>
-              <MaterialTextField
+              <Controller
                 name="lastName"
-                inputRef={register({ required: true })}
-                label={t("lastName")}
-                variant="outlined"
+                control={control}
+                rules={{ required: true }}
+                render={({ field: { onChange, value } }) => (
+                  <MaterialTextField
+                    value={value}
+                    onChange={onChange}
+                    label={t("lastName")}
+                    variant="outlined"
+                  />
+                )}
               />
               {errors.lastName && (
                 <span className={"form-errors"}>{t("lastNameRequired")}</span>
@@ -85,14 +104,21 @@ const OnBehalf: FC = () => {
                     {t("removeRecipient")}
                   </button>
                 </div>
-                <MaterialTextField
+                <Controller
                   name="email"
-                  inputRef={register({
+                  control={control}
+                  rules={{
                     pattern:
                       /^([a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)$/i,
-                  })}
-                  label={t("email")}
-                  variant="outlined"
+                  }}
+                  render={({ field: { onChange, value } }) => (
+                    <MaterialTextField
+                      value={value}
+                      onChange={onChange}
+                      label={t("email")}
+                      variant="outlined"
+                    />
+                  )}
                 />
                 {errors.email && (
                   <span className={"form-errors"}>

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -421,6 +421,9 @@ const QueryParamProvider: FC = ({ children }) => {
                 config.data.loc && config.data.loc.postalCode
                   ? config.data.loc.postalCode
                   : "",
+              country: config.data.loc?.countryCode
+                ? config.data.loc.countryCode
+                : "",
             };
           });
         }


### PR DESCRIPTION
Updates react-hook-form from v6.14 to v7.43, as v is not compatible with React 18 (needed for upgrade to Next 13)

Changes in this pull request:
1. Updates dependency for React Hook Form
2. Replaces use of `register` with `Controller` wrapper around MUI input components
3. Minor changes to resolve warnings while populating contact form details
4. Minor change to multi line message field in GiftForm to add min/max row restrictions