### PR TITLE
DRAFT : Temporary hack to handle donation creation failure

### DIFF
--- a/src/Donations/Components/PaymentsForm.tsx
+++ b/src/Donations/Components/PaymentsForm.tsx
@@ -334,7 +334,8 @@ function PaymentsForm(): ReactElement {
               }
             >
               <InfoIcon />
-              {paymentError}
+              {/* TODO - better error handling */}
+              {t(paymentError)}
             </div>
           )}
           {!isCreatingDonation &&

--- a/src/Donations/PaymentMethods/PaymentFunctions.ts
+++ b/src/Donations/PaymentMethods/PaymentFunctions.ts
@@ -17,6 +17,7 @@ import { Donation, DonationRequestData } from "src/Common/Types/donation";
 import { PaymentMethod } from "@stripe/stripe-js/types/api/payment-methods";
 import { PaymentIntentResult, Stripe, StripeError } from "@stripe/stripe-js";
 import { Dispatch, SetStateAction } from "react";
+import { APIError, handleError } from "@planet-sdk/common";
 
 export function buildPaymentProviderRequest(
   gateway: string,
@@ -149,7 +150,11 @@ export async function createDonationFunction({
       return donation.data as Donation;
     }
   } catch (error) {
-    if (error.status === 400) {
+    // hack to address errors when donation was not created. Previous incorrect error handling logic is commented below for reference.
+    // TODO - better error handling
+    const serializedErrors = handleError(error as APIError);
+    setPaymentError(serializedErrors[0]?.message || error.message);
+    /* if (error.status === 400) {
       setPaymentError(error.data.message);
     } else if (error.status === 500) {
       setPaymentError("Something went wrong please try again soon!");
@@ -159,7 +164,7 @@ export async function createDonationFunction({
       );
     } else {
       setPaymentError(error.message);
-    }
+    } */
     setIsPaymentProcessing(false);
   }
 }

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -189,10 +189,21 @@ const QueryParamProvider: FC = ({ children }) => {
   }, [currency, enabledCurrencies]);
 
   useEffect(() => {
+    // hack to address errors when donation was not created.
+    // TODO - better error handling
     if (paymentError) {
-      router.replace({
-        query: { ...router.query, step: THANK_YOU },
-      });
+      if (paymentError === "validationError") {
+        setErrors([
+          {
+            message: paymentError,
+            errorType: "validation_error",
+          },
+        ]);
+      } else {
+        router.replace({
+          query: { ...router.query, step: THANK_YOU },
+        });
+      }
     }
   }, [paymentError]);
   useEffect(() => {


### PR DESCRIPTION
After submitting contact details while creating a postpaid donation, if there was an issue, the user was briefly flashed an error message and then redirected to the thank_you step with just a loader visible.

This PR creates a hack to provide some persistent information about the error in such a scenario.

This scenario would occur most likely in the case of a validation failure from the API while returning a donation.