### PR TITLE
Fixes payment retry issue where user got stuck on "Seeding your donation"

### DIFF
--- a/src/Donations/Components/PaymentsForm.tsx
+++ b/src/Donations/Components/PaymentsForm.tsx
@@ -176,6 +176,11 @@ function PaymentsForm(): ReactElement {
       tenant,
       locale: i18n.language,
     });
+    if (router.query.to) {
+      router.replace({
+        query: { ...router.query, step: PAYMENT },
+      });
+    }
     if (router.query.context) {
       router.replace({
         query: { context: donation?.id, step: PAYMENT },


### PR DESCRIPTION
On retrying payment after a failed donation, the user would get stuck on the "Seeding your donation" loader. This has been resolved. 

NOTE: should be merged to develop only after #387.