### PR TITLE
Disable email field in contact form

### DIFF
--- a/src/Donations/Components/ContactsForm.tsx
+++ b/src/Donations/Components/ContactsForm.tsx
@@ -260,7 +260,7 @@ function ContactsForm(): ReactElement {
                   label={t("email")}
                   variant="outlined"
                   data-test-id="test-email"
-                  disabled={isAuthenticated}
+                  disabled={profile?.email.length !== 0}
                 />
               )}
             />

--- a/src/Donations/Components/ContactsForm.tsx
+++ b/src/Donations/Components/ContactsForm.tsx
@@ -260,7 +260,7 @@ function ContactsForm(): ReactElement {
                   label={t("email")}
                   variant="outlined"
                   data-test-id="test-email"
-                  disabled={profile?.email.length !== 0}
+                  disabled={profile !== null && profile?.email.length !== 0}
                 />
               )}
             />


### PR DESCRIPTION
When a user is logged in on the webapp and selects a project to donate to, they are able to edit the email that is within the contact details. This should not be possible, like it is not when you directly log in on donate.