### PR TITLE
Corrects contact form validation for authenticated user without a profile

### DIFF
--- a/src/Donations/Components/ContactsForm.tsx
+++ b/src/Donations/Components/ContactsForm.tsx
@@ -425,7 +425,7 @@ function ContactsForm(): ReactElement {
             <></>
           )}
 
-          {profile === null && (
+          {(profile === null || profile.type === undefined) && (
             <div className="contacts-isCompany-toggle mt-20">
               <label htmlFor="isCompany-toggle">
                 {t("isACompanyDonation")}
@@ -449,7 +449,10 @@ function ContactsForm(): ReactElement {
             </div>
           )}
 
-          {isCompany || (profile && profile.type !== "individual") ? (
+          {isCompany ||
+          (profile &&
+            profile.type !== "individual" &&
+            profile.type !== undefined) ? (
             <div
               className={`form-field ${profile === null ? "mt-20" : "mt-30"}`}
             >
@@ -464,7 +467,7 @@ function ContactsForm(): ReactElement {
                     label={t("companyName")}
                     variant="outlined"
                     data-test-id="test-companyname"
-                    disabled={profile !== null}
+                    disabled={profile !== null && profile.type !== undefined}
                     helperText={
                       profile !== null ? t("companyUneditableHelpText") : ""
                     }

--- a/src/Donations/Micros/Authentication.tsx
+++ b/src/Donations/Micros/Authentication.tsx
@@ -91,9 +91,12 @@ function Authentication(): ReactElement {
         const newContactDetails = {
           firstname: authUser?.nickname ? authUser.nickname : "",
           email: authUser?.email ? authUser.email : "",
+        };
+        const newProfile = {
+          ...newContactDetails,
           displayName: authUser?.nickname ? authUser.nickname : "",
         };
-        setprofile(newContactDetails); //TODOO - resolve TS warning
+        setprofile(newProfile); //TODOO - resolve TS warning
         setContactDetails((contactDetails) => {
           return { ...contactDetails, ...newContactDetails };
         });
@@ -102,9 +105,12 @@ function Authentication(): ReactElement {
       const newContactDetails = {
         firstname: authUser?.nickname ? authUser.nickname : "",
         email: authUser?.email ? authUser.email : "",
+      };
+      const newProfile = {
+        ...newContactDetails,
         displayName: authUser?.nickname ? authUser.nickname : "",
       };
-      setprofile(newContactDetails); //TODOO - resolve TS warning
+      setprofile(newProfile); //TODOO - resolve TS warning
       setContactDetails((contactDetails) => {
         return { ...contactDetails, ...newContactDetails };
       });


### PR DESCRIPTION
1. isCompany toggle is shown for guest users and authenticated users without a profile.
2. companyName field is shown for guest users and authenticated users without a profile if isCompany toggle is on.
3. displayName is no longer sent while creating a donation for an authenticated user without a profile