### PR TITLE
Temporarily disable native payment options

### DIFF
--- a/src/Donations/Components/DonationsForm.tsx
+++ b/src/Donations/Components/DonationsForm.tsx
@@ -383,7 +383,7 @@ function DonationsForm(): ReactElement {
               projectDetails.purpose === "conservation") && <DonationAmount />}
 
             {/* Hide NativePay if PlanetCash is active */}
-
+            {/* 9 May 2023 - Apple Pay / Google Pay is disabled currently as it is not working correctly*/}
             {!isPlanetCashActive ? (
               paymentSetup && paymentSetup?.unitCost && projectDetails ? (
                 minAmt && paymentSetup?.unitCost * quantity >= minAmt ? (
@@ -391,6 +391,8 @@ function DonationsForm(): ReactElement {
                   paymentSetup?.gateways?.stripe?.account &&
                   currency ? (
                     <NativePay
+                      isApplePayEnabled={false}
+                      isGooglePayEnabled={false}
                       country={country}
                       currency={currency}
                       amount={formatAmountForStripe(

--- a/src/Donations/PaymentMethods/PaymentMethodTabs.tsx
+++ b/src/Donations/PaymentMethods/PaymentMethodTabs.tsx
@@ -215,8 +215,11 @@ export default function PaymentMethodTabs({
             <CheckMark />
           </button>
         )}
+        {/*9 May 2023 - Apple Pay / Google Pay is disabled currently as it is not working correctly*/}
         {showNativePay && (
           <NativePay
+            isApplePayEnabled={false}
+            isGooglePayEnabled={false}
             country={country}
             currency={currency}
             amount={formatAmountForStripe(

--- a/src/Donations/PaymentMethods/PaymentRequestCustomButton.tsx
+++ b/src/Donations/PaymentMethods/PaymentRequestCustomButton.tsx
@@ -29,6 +29,8 @@ interface PaymentButtonProps {
   paymentLabel: string;
   frequency: string | null;
   paymentSetup: PaymentOptions;
+  isApplePayEnabled: boolean;
+  isGooglePayEnabled: boolean;
 }
 
 export const PaymentRequestCustomButton = ({
@@ -41,6 +43,8 @@ export const PaymentRequestCustomButton = ({
   paymentLabel,
   frequency,
   paymentSetup,
+  isApplePayEnabled,
+  isGooglePayEnabled,
 }: PaymentButtonProps): ReactElement | null => {
   const { t, ready } = useTranslation(["common"]);
   const { paymentRequest, setPaymentRequest } = useContext(QueryParamContext);
@@ -142,7 +146,8 @@ export const PaymentRequestCustomButton = ({
       (frequency !== "once"
         ? paymentSetup?.recurrency?.methods?.includes("card")
         : true) ? (
-        paymentRequest._canMakePaymentAvailability.APPLE_PAY ? ( //TODOO - is _canMakePaymentAvailability a private variable?
+        paymentRequest._canMakePaymentAvailability.APPLE_PAY &&
+        isApplePayEnabled ? ( //TODOO - is _canMakePaymentAvailability a private variable?
           <div className="w-100">
             <button
               onClick={() => paymentRequest.show()}
@@ -165,7 +170,8 @@ export const PaymentRequestCustomButton = ({
               <div className="separator-text mb-10">{t("or")}</div>
             )}
           </div>
-        ) : paymentRequest._canMakePaymentAvailability.GOOGLE_PAY ? ( //TODOO - is _canMakePaymentAvailability a private variable?
+        ) : paymentRequest._canMakePaymentAvailability.GOOGLE_PAY &&
+          isGooglePayEnabled ? ( //TODOO - is _canMakePaymentAvailability a private variable?
           <div className="w-100">
             <button
               onClick={() => {
@@ -206,7 +212,11 @@ export const PaymentRequestCustomButton = ({
   ) : null;
 };
 
+/* 9 May 2023 - Apple Pay / Google Pay is disabled currently as it is not working correctly*/
+
 interface NativePayProps {
+  isApplePayEnabled: boolean;
+  isGooglePayEnabled: boolean;
   country: string;
   currency: string;
   amount: number;
@@ -221,6 +231,8 @@ interface NativePayProps {
   frequency: string | null;
 }
 export const NativePay = ({
+  isApplePayEnabled = false,
+  isGooglePayEnabled = false,
   country,
   currency,
   amount,
@@ -268,6 +280,8 @@ export const NativePay = ({
         paymentLabel={paymentLabel}
         frequency={frequency}
         paymentSetup={paymentSetup}
+        isApplePayEnabled={isApplePayEnabled}
+        isGooglePayEnabled={isGooglePayEnabled}
       />
     </Elements>
   );


### PR DESCRIPTION
As there are double charging issues seen in Apple pay, native payment options are disabled until a fix is found.