### PR TITLE
Ensure that no giftData is sent to backend when topping up PlanetCash

### DIFF
--- a/src/Donations/LeftPanel/LeftPanelInfo.tsx
+++ b/src/Donations/LeftPanel/LeftPanelInfo.tsx
@@ -66,7 +66,8 @@ const LeftPanelInfo = ({
     (donationStep === 1 || donationStep === 2 || donationStep === 3) &&
     giftDetails.type !== null &&
     isGift &&
-    giftDetails.recipientName !== undefined;
+    giftDetails.recipientName !== undefined &&
+    projectDetails?.purpose !== "planet-cash";
   const canShowOnBehalf =
     donationStep === 1 &&
     isPlanetCashActive &&
@@ -96,10 +97,7 @@ const LeftPanelInfo = ({
           )}
         </div>
       )}
-      {canShowGift &&
-        router.query.to?.toString().toLowerCase() !== "planetcash" && (
-          <GiftInfo giftDetails={giftDetails} />
-        )}
+      {canShowGift && <GiftInfo giftDetails={giftDetails} />}
       {canShowOnBehalf && <OnBehalfInfo onBehalfDonor={onBehalfDonor} />}
       {canShowContactDetails && (
         <ContactDetailsInfo contactDetails={contactDetails} />

--- a/src/Donations/LeftPanel/LeftPanelInfo.tsx
+++ b/src/Donations/LeftPanel/LeftPanelInfo.tsx
@@ -96,7 +96,10 @@ const LeftPanelInfo = ({
           )}
         </div>
       )}
-      {canShowGift && <GiftInfo giftDetails={giftDetails} />}
+      {canShowGift &&
+        router.query.to?.toString().toLowerCase() !== "planetcash" && (
+          <GiftInfo giftDetails={giftDetails} />
+        )}
       {canShowOnBehalf && <OnBehalfInfo onBehalfDonor={onBehalfDonor} />}
       {canShowContactDetails && (
         <ContactDetailsInfo contactDetails={contactDetails} />

--- a/src/Donations/PaymentMethods/PaymentFunctions.ts
+++ b/src/Donations/PaymentMethods/PaymentFunctions.ts
@@ -177,8 +177,6 @@ export function createDonationData({
   currency,
   contactDetails,
   taxDeductionCountry,
-  isGift,
-  giftDetails,
   frequency,
   amount,
   callbackUrl,

--- a/src/Donations/PaymentMethods/PaymentFunctions.ts
+++ b/src/Donations/PaymentMethods/PaymentFunctions.ts
@@ -177,6 +177,8 @@ export function createDonationData({
   currency,
   contactDetails,
   taxDeductionCountry,
+  isGift,
+  giftDetails,
   frequency,
   amount,
   callbackUrl,
@@ -213,6 +215,32 @@ export function createDonationData({
     };
   }
 
+  if (isGift) {
+    if (giftDetails.type === "invitation") {
+      donationData = {
+        ...donationData,
+        ...{
+          gift: {
+            type: "invitation",
+            recipientName: giftDetails.recipientName,
+            recipientEmail: giftDetails.recipientEmail,
+            message: giftDetails.message,
+          },
+        },
+      };
+    } else if (giftDetails.type === "direct") {
+      donationData = {
+        ...donationData,
+        ...{
+          gift: {
+            type: "direct",
+            recipient: giftDetails.recipient,
+          },
+        },
+      };
+    }
+  }
+
   if (projectDetails?.purpose === "planet-cash") {
     // For PlanetCash Top-up
 
@@ -221,6 +249,9 @@ export function createDonationData({
 
     // Since a user account can have only one planetCash account no need to send project (i.e planetCash account ID).
     delete donationData.project;
+
+    //should not send gift details
+    delete donationData.gift;
   }
 
   return donationData;

--- a/src/Donations/PaymentMethods/PaymentFunctions.ts
+++ b/src/Donations/PaymentMethods/PaymentFunctions.ts
@@ -215,32 +215,6 @@ export function createDonationData({
     };
   }
 
-  if (isGift) {
-    if (giftDetails.type === "invitation") {
-      donationData = {
-        ...donationData,
-        ...{
-          gift: {
-            type: "invitation",
-            recipientName: giftDetails.recipientName,
-            recipientEmail: giftDetails.recipientEmail,
-            message: giftDetails.message,
-          },
-        },
-      };
-    } else if (giftDetails.type === "direct") {
-      donationData = {
-        ...donationData,
-        ...{
-          gift: {
-            type: "direct",
-            recipient: giftDetails.recipient,
-          },
-        },
-      };
-    }
-  }
-
   if (projectDetails?.purpose === "planet-cash") {
     // For PlanetCash Top-up
 


### PR DESCRIPTION
When topping up PlanetCash sending giftData will result in an error “extra field”. This is the case for direct as well as invitation gifts.

This PR focuses on removing the additional `gift` field that was being sent in the request