### PR TITLE
Sends `welcomePackageStatus = draft` only when eligible

### DIFF
--- a/src/Donations/Components/ContactsForm.tsx
+++ b/src/Donations/Components/ContactsForm.tsx
@@ -62,12 +62,12 @@ function ContactsForm(): ReactElement {
 
   React.useEffect(() => {
     if (contactDetails) {
-      reset({ ...contactDetails, isPackageWanted: isPackageWanted !== false });
+      reset({ ...contactDetails, isPackageWanted: isPackageWanted !== false && isEligibleForPackage });
       if (contactDetails.companyname) {
         setIsCompany(true);
       }
     }
-  }, [contactDetails, isPackageWanted]);
+  }, [contactDetails, isPackageWanted, isEligibleForPackage]);
 
   const {
     handleSubmit,
@@ -103,7 +103,7 @@ function ContactsForm(): ReactElement {
         ? contactDetails.email
         : enteredContactDetails.email,
     });
-    setIsPackageWanted(isPackageWanted);
+    setIsPackageWanted(isEligibleForPackage ? isPackageWanted : null);
   };
 
   const [postalRegex, setPostalRegex] = React.useState(


### PR DESCRIPTION
Fixes a bug that set `welcomePackageStatus = draft` even when user was not eligible for welcome package (i.e. invalid project and/or country).

Ensures that `isPackageWanted` within `QueryParamContext` remains null if not eligible for package