### PR TITLE
Add profile query param to paymentOptions call

### DIFF
--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -361,7 +361,7 @@ const QueryParamProvider: FC = ({ children }) => {
         shouldSetPaymentDetails: true,
       });
     }
-  }, [router.query.to, country]);
+  }, [router.query.to, country, profile]);
 
   async function loadConfig() {
     try {
@@ -490,7 +490,9 @@ const QueryParamProvider: FC = ({ children }) => {
     setIsPaymentOptionsLoading(true);
     try {
       const requestParams = {
-        url: `/app/paymentOptions/${projectGUID}?country=${paymentSetupCountry}`,
+        url: `/app/paymentOptions/${projectGUID}?country=${paymentSetupCountry}${
+          profile !== null ? `&profile=${profile?.id}` : ""
+        }`,
         setshowErrorCard,
         tenant,
         locale: i18n.language,


### PR DESCRIPTION
This pull request adds the new `profile` query parameter to the payment options loading process, allowing customization of the paymentOptions response based on user.

This change ensures that the correct payment options are loaded based on the selected profile.