### PR TITLE
Allow PlanetCash payments for more types of donations

### DIFF
--- a/src/Common/Types/index.tsx
+++ b/src/Common/Types/index.tsx
@@ -227,6 +227,7 @@ export interface Gateways {
   paypal: Paypal;
   stripe: Stripe;
   offline?: Offline;
+  "planet-cash"?: PlanetCashGateway;
 }
 export interface Paypal {
   methods?: string[] | null;
@@ -252,6 +253,13 @@ export interface AuthorizationStripe {
 export interface Offline {
   methods?: string[] | null;
   account: string;
+}
+
+export interface PlanetCashGateway {
+  account: string;
+  balance: number;
+  creditLimit: number;
+  available: number;
 }
 
 export interface OptionsEntity {

--- a/src/Donations/Components/DonationsForm.tsx
+++ b/src/Donations/Components/DonationsForm.tsx
@@ -35,6 +35,7 @@ import {
 import { PaymentMethod } from "@stripe/stripe-js/types/api/payment-methods";
 import { PaymentRequest } from "@stripe/stripe-js/types/stripe-js/payment-request";
 import { NON_GIFTABLE_PROJECT_PURPOSES } from "src/Utils/projects/constants";
+import { isPlanetCashAllowed } from "src/Utils/donationOptions";
 
 function DonationsForm(): ReactElement {
   const {
@@ -117,19 +118,13 @@ function DonationsForm(): ReactElement {
   const [isPaymentProcessing, setIsPaymentProcessing] = React.useState(false);
   const [paymentError, setPaymentError] = React.useState(""); //TODOO - confirm and remove
 
-  const canPayWithPlanetCash =
-    projectDetails !== null &&
-    projectDetails.purpose !== "funds" &&
-    projectDetails.purpose !== "planet-cash" &&
-    paymentSetup?.unitType === "tree" && //Enables planetcash for restoration projects with unitType tree only (TEMP)
-    profile !== null &&
-    isSignedUp &&
-    profile.planetCash !== null &&
-    projectDetails.taxDeductionCountries?.includes(
-      profile.planetCash.country
-    ) &&
-    !(isGift && giftDetails.recipientName === "") &&
-    !(onBehalf && onBehalfDonor.firstName === "");
+  const canPayWithPlanetCash = isPlanetCashAllowed({
+    profile,
+    isSignedUp,
+    projectDetails,
+    isGift,
+    giftDetails,
+  });
 
   const canSendDirectGift =
     projectDetails !== null &&
@@ -385,7 +380,6 @@ function DonationsForm(): ReactElement {
           {projectDetails.purpose !== "funds" && (
             <p className="title-text">{t("donate")}</p>
           )}
-          {/* show PlanetCashSelector only if user is signed up and have a planetCash account */}
           {canPayWithPlanetCash && <PlanetCashSelector />}
           {(canSendDirectGift && hasDirectGift) || canSendInvitationGift ? (
             <div className="donations-gift-container mt-10">

--- a/src/Donations/Components/DonationsForm.tsx
+++ b/src/Donations/Components/DonationsForm.tsx
@@ -293,11 +293,6 @@ function DonationsForm(): ReactElement {
   const handlePlanetCashDonate = async () => {
     if (projectDetails) {
       setShowDisablePlanetCashButton(true);
-      const _onBehalfDonor = {
-        firstname: onBehalfDonor.firstName,
-        lastname: onBehalfDonor.lastName,
-        email: onBehalfDonor.email,
-      };
 
       const _metadata = {
         utm_campaign: utmCampaign,

--- a/src/Donations/Components/DonationsForm.tsx
+++ b/src/Donations/Components/DonationsForm.tsx
@@ -124,6 +124,7 @@ function DonationsForm(): ReactElement {
     projectDetails,
     isGift,
     giftDetails,
+    hasPlanetCashGateway: paymentSetup?.gateways["planet-cash"] !== undefined,
   });
 
   const canSendDirectGift =

--- a/src/Utils/donationOptions.ts
+++ b/src/Utils/donationOptions.ts
@@ -1,0 +1,40 @@
+import { NoGift, User } from "@planet-sdk/common";
+import {
+  PLANETCASH_ALLOWED_PROJECT_PURPOSES,
+  PLANETCASH_DISALLOWED_PROJECT_CLASSIFICATIONS,
+} from "./projects/constants";
+import { FetchedProjectDetails, GiftDetails } from "src/Common/Types";
+
+interface PlanetCashAllowedParams {
+  profile: User | null;
+  isSignedUp: boolean;
+  projectDetails: FetchedProjectDetails | null;
+  isGift: boolean;
+  giftDetails: GiftDetails | NoGift;
+}
+
+/**
+ * Determines if Planet Cash is allowed for the current donation
+ */
+export const isPlanetCashAllowed = ({
+  profile,
+  isSignedUp,
+  projectDetails,
+  isGift,
+  giftDetails,
+}: PlanetCashAllowedParams): boolean => {
+  return (
+    profile !== null &&
+    isSignedUp &&
+    profile.planetCash !== null &&
+    projectDetails !== null &&
+    PLANETCASH_ALLOWED_PROJECT_PURPOSES.includes(projectDetails.purpose) &&
+    (projectDetails.classification === null ||
+      !PLANETCASH_DISALLOWED_PROJECT_CLASSIFICATIONS.includes(
+        projectDetails.classification
+      )) &&
+    projectDetails.taxDeductionCountries !== undefined &&
+    projectDetails.taxDeductionCountries.includes(profile.planetCash.country) &&
+    !(isGift && giftDetails.recipientName === "")
+  );
+};

--- a/src/Utils/donationOptions.ts
+++ b/src/Utils/donationOptions.ts
@@ -11,6 +11,7 @@ interface PlanetCashAllowedParams {
   projectDetails: FetchedProjectDetails | null;
   isGift: boolean;
   giftDetails: GiftDetails | NoGift;
+  hasPlanetCashGateway: boolean;
 }
 
 /**
@@ -22,11 +23,13 @@ export const isPlanetCashAllowed = ({
   projectDetails,
   isGift,
   giftDetails,
+  hasPlanetCashGateway,
 }: PlanetCashAllowedParams): boolean => {
   return (
     profile !== null &&
     isSignedUp &&
     profile.planetCash !== null &&
+    hasPlanetCashGateway &&
     projectDetails !== null &&
     PLANETCASH_ALLOWED_PROJECT_PURPOSES.includes(projectDetails.purpose) &&
     (projectDetails.classification === null ||

--- a/src/Utils/projects/constants.ts
+++ b/src/Utils/projects/constants.ts
@@ -1,1 +1,17 @@
-export const NON_GIFTABLE_PROJECT_PURPOSES = ["planet-cash", "bouquet"];
+import { ProjectPurpose, TreeProjectClassification } from "@planet-sdk/common";
+import { FundsProjectClassification } from "src/Common/Types";
+
+export const NON_GIFTABLE_PROJECT_PURPOSES: Array<ProjectPurpose> = [
+  "planet-cash",
+  "bouquet",
+];
+
+export const PLANETCASH_ALLOWED_PROJECT_PURPOSES: Array<ProjectPurpose> = [
+  "trees",
+  "conservation",
+  "funds",
+];
+
+export const PLANETCASH_DISALLOWED_PROJECT_CLASSIFICATIONS: Array<
+  FundsProjectClassification | TreeProjectClassification
+> = ["membership", "endowment"];


### PR DESCRIPTION
- Updates logic to display PlanetCash payment selector to allow more types of donations 
- Extract logic for determining Planet Cash eligibility into a utility function, simplifying the DonationsForm component.
- Adds constants related to project purposes and classifications for better clarity.

Updated logic - 
1. PlanetCash is allowed for one time donations to all projects with `purpose: "trees" | "conservation" | "funds"` with the exception of projects classified as `membership` or `endowment`.  
2. To use PlanetCash, the user must be logged in, and have a PlanetCash account for a country included in the taxDeductibleCountries for the project
3. The gift form should not be currently open (`isGift` and `giftDetails.recipientName = "")

For recurring donations, the planet cash selector, if shown (based on other conditions), will be disabled.

As `onBehalf` is not used in the project, checks based on that have been removed

Pending

- [x] Hide PlanetCash selector based on `/paymentOptions` API response (`gateways.planet-cash` should exist)
- [x] `/paymentOptions` API should be authenticated if needed