### PR TITLE
Allow gift query parameter for more project types

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -455,8 +455,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     }
   }
 
-  // Set gift details if gift = true in the query params (only for tree projects)
+  // Set gift details if gift = true in the query params
   if (
+    giftDetails?.type !== "direct" &&
     context.query.gift === "true" &&
     projectDetails !== null &&
     !NON_GIFTABLE_PROJECT_PURPOSES.includes(projectDetails.purpose)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -456,7 +456,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   }
 
   // Set gift details if gift = true in the query params (only for tree projects)
-  if (context.query.gift === "true" && projectDetails?.purpose === "trees") {
+  if (
+    context.query.gift === "true" &&
+    projectDetails !== null &&
+    !NON_GIFTABLE_PROJECT_PURPOSES.includes(projectDetails.purpose)
+  ) {
     isGift = true;
     giftDetails = {
       type: "invitation",

--- a/src/Common/Types/index.tsx
+++ b/src/Common/Types/index.tsx
@@ -14,11 +14,11 @@ import {
 } from "@planet-sdk/common";
 
 /** planet-donations only allows direct or invitation gifts */
-export type DirectGiftDetails = SentDirectGift & {
+export interface DirectGiftDetails extends SentDirectGift {
   recipientName?: string;
   recipientProfile?: string;
-};
-export type InvitationGiftDetails = SentInvitationGift;
+}
+export interface InvitationGiftDetails extends SentInvitationGift {}
 
 export type SentGift = SentDirectGift | SentInvitationGift;
 


### PR DESCRIPTION
Enhance the handling of the gift query parameter to support additional project types beyond just tree projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved validation for gift eligibility, ensuring only valid projects can be associated with gifts.

- **Bug Fixes**
	- Enhanced checks for project details to prevent null values and ensure compliance with giftable project criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->