### PR TITLE
add purpose filter with trees, conservation and restoration

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,15 +9,16 @@ jobs:
     name: 'ESLint on Ubuntu'
     runs-on: ubuntu-latest  # Can be self-hosted runner also
     steps:
-
       - name: 'Checkout the repository'
         uses: actions/checkout@v2
 
-      - name: Upgrade npm to latest version
-        run: sudo npm i -g npm@latest
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
 
       - name: 'Install Node Modules'
-        run: npm install
+        run: npm install --legacy-peer-deps
 
       - name: 'Running ESLint only showing errors'
         run: npm run lint:errors

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -238,7 +238,7 @@ const QueryParamProvider: FC = ({ children }) => {
   async function loadselectedProjects() {
     try {
       const requestParams = {
-        url: `/app/projects?_scope=map`,
+        url: `/app/projects?_scope=map&filter[purpose]=trees,restoration,conservation`,
         setshowErrorCard,
         tenant,
         locale: i18n.language,


### PR DESCRIPTION
Additionally to @jmiridis having added some default filtering in case a filter is missing to the api endpoint to retrieve the project list as the app crashed with the latest results (e.g. not containing some tpo property for some projects), we maybe should add some filtering as well into the frontend. This is just a quick fix. Please review what kind of filter might be wanted for this application. I used the same now as done by @jmiridis in the backend. Compare this thread: https://planetfoundation.slack.com/archives/C02393H3GDC/p1736524954057429

(Also adapted faulty GitHub action for linting.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced project filtering in the application
	- Limited project selection to specific purposes (trees, restoration, conservation)  
- **Chores**
	- Updated Node.js environment setup in the ESLint workflow
	- Modified dependency installation process to improve compatibility
<!-- end of auto-generated comment: release notes by coderabbit.ai -->