### PR TITLE
Add maxLength validation for zipCode in ContactsForm

### DIFF
--- a/src/Donations/Components/ContactsForm.tsx
+++ b/src/Donations/Components/ContactsForm.tsx
@@ -410,6 +410,10 @@ function ContactsForm(): ReactElement {
                     value: postalRegex as RegExp,
                     message: t("zipCodeInvalid"),
                   },
+                  maxLength: {
+                    value: 15,
+                    message: t("zipCodeInvalid"),
+                  },
                 }}
                 render={({ field: { onChange, value, onBlur } }) => (
                   <MaterialTextField


### PR DESCRIPTION
Add maxLength validation to the zipCode field in the ContactsForm to ensure input does not exceed 15 characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the donation contact form by restricting the zip code input to a maximum of 15 characters, ensuring users receive clear feedback when entering an overly long zip code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->