### PR TITLE
Update links to use the webapp domain

### DIFF
--- a/src/Donations/LeftPanel/Avatar.tsx
+++ b/src/Donations/LeftPanel/Avatar.tsx
@@ -14,7 +14,7 @@ const Avatar = ({ info }: Props): ReactElement => {
 
   const renderAvatarImage = (
     ownerName: string | null,
-    ownerAvatar: string | null,
+    ownerAvatar: string | null
   ): JSX.Element => {
     return ownerAvatar ? (
       <img
@@ -32,7 +32,7 @@ const Avatar = ({ info }: Props): ReactElement => {
     <a
       rel="noreferrer"
       target="_blank"
-      href={`https://www.trilliontreecampaign.org/${info.id}`}
+      href={`https://web.plant-for-the-planet.org/${info.id}`}
       className={styles["avatar-link"]}
     >
       {renderAvatarImage(ownerName, ownerAvatar)}

--- a/src/Donations/LeftPanel/GiftInfo.tsx
+++ b/src/Donations/LeftPanel/GiftInfo.tsx
@@ -17,7 +17,7 @@ const GiftInfo = ({ giftDetails }: Props): ReactElement => {
         <a
           rel="noreferrer"
           target="_blank"
-          href={`https://www.trilliontreecampaign.org/t/${giftDetails.recipientProfile}`}
+          href={`https://web.plant-for-the-planet.org/t/${giftDetails.recipientProfile}`}
           className={styles["gift-recipient"]}
         >
           {giftDetails.recipientName}

--- a/src/Donations/LeftPanel/SummaryTitle.tsx
+++ b/src/Donations/LeftPanel/SummaryTitle.tsx
@@ -19,7 +19,7 @@ const ProjectTitle = ({ info }: Props): ReactElement => {
         <a
           rel="noreferrer"
           target="_blank"
-          href={`https://www.trilliontreecampaign.org/${info.id}`}
+          href={`https://web.plant-for-the-planet.org/${info.id}`}
         >
           {info.name + "    "}
         </a>

--- a/src/Donations/Micros/Authentication.tsx
+++ b/src/Donations/Micros/Authentication.tsx
@@ -192,7 +192,7 @@ function Authentication(): ReactElement {
         <div className="d-flex row justify-content-between w-100 mb-20">
           {!profile?.isPrivate ? (
             <a
-              href={`https://www1.plant-for-the-planet.org/t/${profile?.slug}`}
+              href={`https://web.plant-for-the-planet.org/t/${profile?.slug}`}
               target={"_blank"}
               rel="noreferrer"
             >


### PR DESCRIPTION
Update all relevant links to point to the new webapp domain (web.plant-for-the-planet.org) instead of www.trilliontreecampaign.org or www1.plant-for-the-planet.org

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated donation-related links so that users are now directed to the new campaign site (plant-for-the-planet.org) instead of the previous destination. The update applies to avatar displays, gift details, project titles, and user profiles, ensuring a consistent and correct navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->