### PR TITLE
Add X-Locale header to donation POST requests

### DIFF
--- a/src/Donations/Components/DonationsForm.tsx
+++ b/src/Donations/Components/DonationsForm.tsx
@@ -351,6 +351,9 @@ function DonationsForm(): ReactElement {
           addIdempotencyKeyHeader: true,
           tenant,
           locale: i18n.language,
+          headers: {
+            "X-Locale": i18n.language,
+          },
         });
 
         if (status === 200) {

--- a/src/Donations/PaymentMethods/PaymentFunctions.ts
+++ b/src/Donations/PaymentMethods/PaymentFunctions.ts
@@ -150,6 +150,9 @@ export async function createDonationFunction({
       tenant,
       locale,
       token: token ? token : null,
+      headers: {
+        "X-Locale": locale,
+      },
     };
     const donation = await apiRequest(requestParams);
     if (donation && donation.data) {


### PR DESCRIPTION
Include the X-Locale header in donation requests to support localization of certificates.

