### PR TITLE
Remove 'US' from allowedCountries in PlanetCashSignup

### DIFF
--- a/src/Donations/Micros/PlanetCashSignup.tsx
+++ b/src/Donations/Micros/PlanetCashSignup.tsx
@@ -30,7 +30,7 @@ interface PlanetCashAccount {
   fee: number;
 }
 
-const allowedCountries = ["DE", "ES", "US"];
+const allowedCountries = ["DE", "ES"];
 
 const PlanetCashSignup = (): ReactElement => {
   const { t, i18n } = useTranslation(["common"]);


### PR DESCRIPTION
Remove 'US' from the list of allowed countries in the PlanetCashSignup component.