### PR TITLE
Update eslint-config-prettier version to ~8.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "eslint": "^7.23.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-next": "^14.2.30",
-        "eslint-config-prettier": "^8.1.0",
+        "eslint-config-prettier": "~8.7.0",
         "eslint-plugin-i18next": "^5.1.1",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint": "^7.23.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-next": "^14.2.30",
-    "eslint-config-prettier": "^8.1.0",
+    "eslint-config-prettier": "~8.7.0",
     "eslint-plugin-i18next": "^5.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",


### PR DESCRIPTION
A recent minor version 8.10.1 of eslint-config-prettier contains malware

https://invokere.com/posts/2025/07/scavenger-malware-distributed-via-eslint-config-prettier-npm-package-supply-chain-compromise/

Using the tilde (~) instead of caret (^) restricts updates to patch versions only (8.7.x), preventing the vulnerable minor version from being automatically installed while still allowing safe patch updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version range for a development dependency to restrict updates to patch-level releases only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->