### PR TITLE
fix: sync NEXT_LOCALE cookie on locale redirects to prevent redirect loop

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -31,14 +31,19 @@ export async function middleware(
     if (!tenantSupportedLanguages.includes(currentLocale)) {
       const fallbackLocale = tenantSupportedLanguages[0] || "en";
 
-      // Build redirect URL with correct locale
-      // Uses req.nextUrl.pathname (already normalized, no locale) and prepends new locale
-      return NextResponse.redirect(
+      const response = NextResponse.redirect(
         new URL(
           `/${fallbackLocale}${req.nextUrl.pathname}${req.nextUrl.search}`,
           req.url,
         ),
       );
+      // Overwrite the cookie so Next.js doesn't redirect back to the unsupported locale on the next request
+      response.cookies.set("NEXT_LOCALE", fallbackLocale, {
+        path: "/",
+        maxAge: 31536000,
+        sameSite: "lax",
+      });
+      return response;
     }
   }
 
@@ -57,30 +62,50 @@ export async function middleware(
         if (!tenantConfig.languages.includes(localeParam)) {
           // Redirect to tenant's first supported language
           const fallbackLocale = tenantConfig.languages[0] || "en";
-          return NextResponse.redirect(
+          const response = NextResponse.redirect(
             new URL(
               `/${fallbackLocale}${req.nextUrl.pathname}${queryString}`,
               req.url,
             ),
           );
+          // Overwrite cookie to match the tenant fallback locale
+          response.cookies.set("NEXT_LOCALE", fallbackLocale, {
+            path: "/",
+            maxAge: 31536000,
+            sameSite: "lax",
+          });
+          return response;
         }
       }
 
-      // Convert ?locale=de to /de/
-      return NextResponse.redirect(
+      // ?locale=en is an explicit instruction from the referring app and must take precedence over the user's NEXT_LOCALE cookie.
+      // Without setting the cookie here, Next.js reads the existing NEXT_LOCALE cookie (e.g. "de") on the redirected /en path and immediately overrides back to /de, creating an infinite loop.
+      const response = NextResponse.redirect(
         new URL(
           `/${localeParam}${req.nextUrl.pathname}${queryString}`,
           req.url,
         ),
       );
+      response.cookies.set("NEXT_LOCALE", localeParam, {
+        path: "/",
+        maxAge: 31536000,
+        sameSite: "lax",
+      });
+      return response;
     } else {
-      // Invalid locale param, use current locale
-      return NextResponse.redirect(
+      // Invalid locale param — fall back to current locale
+      const response = NextResponse.redirect(
         new URL(
           `/${currentLocale}${req.nextUrl.pathname}${queryString}`,
           req.url,
         ),
       );
+      response.cookies.set("NEXT_LOCALE", currentLocale, {
+        path: "/",
+        maxAge: 31536000,
+        sameSite: "lax",
+      });
+      return response;
     }
   }
 }


### PR DESCRIPTION
## Problem

Users with a `NEXT_LOCALE` cookie set to a locale not supported by a specific tenant (e.g. `de` for a tenant that only supports `en`) would encounter an `ERR_TOO_MANY_REDIRECTS` error when opening a donation link with an explicit `?locale=` parameter.

### Root cause

The middleware was correctly redirecting to the appropriate locale path, but was not updating the `NEXT_LOCALE` cookie to match. On the very next request, Next.js would read the stale cookie and silently redirect back to the previous locale, undoing the middleware's redirect and creating an infinite loop.

### Example sequence

```
/?locale=en&tenant=ten_61F97F9j        (NEXT_LOCALE=de)
  → middleware: ?locale=en → /en       (cookie unchanged)
  → Next.js: NEXT_LOCALE=de → /de
  → middleware: tenant rejects de → /en (cookie unchanged)
  → Next.js: NEXT_LOCALE=de → /de
  ♾️
```

Clearing browser cookies resolved the loop temporarily, as it removed the conflicting `NEXT_LOCALE` cookie.

## Fix

Overwrite the `NEXT_LOCALE` cookie to match the target locale on every redirect in the middleware. This ensures Next.js always agrees with the middleware's routing decision on the subsequent request.

This applies to three redirect cases:
- **Explicit `?locale=` param** — the referring app's instruction takes precedence over the user's saved preference
- **Tenant doesn't support current locale** — redirect to tenant's fallback locale
- **Invalid `?locale=` param** — redirect to current locale

## Testing

1. Visit preview link and switch language to German (`NEXT_LOCALE=de` is set)
2. Open a donation link with `?locale=en&tenant=ten_61F97F9j`
3. Confirm the page loads in English with no redirect loop
4. Confirm that revisiting the donation link still loads in English
