### PR TITLE
fix(auth): handle email_not_verified denial alongside 401

### DIFF
--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -509,6 +509,7 @@ const QueryParamProvider = ({
     if (router.query.error) {
       // Unverified email: the old platform deny was unauthorized/401; the
       // current PostLogin Action denies with access_denied/email_not_verified.
+			// TODO: Remove unauthorized/401 case after July 31, 2026. Confirm whether safe to remove.
       const isEmailNotVerified =
         (router.query.error_description === "401" &&
           router.query.error === "unauthorized") ||

--- a/src/Layout/QueryParamContext.tsx
+++ b/src/Layout/QueryParamContext.tsx
@@ -507,10 +507,14 @@ const QueryParamProvider = ({
 
   useEffect(() => {
     if (router.query.error) {
-      if (
-        router.query.error_description === "401" &&
-        router.query.error === "unauthorized"
-      ) {
+      // Unverified email: the old platform deny was unauthorized/401; the
+      // current PostLogin Action denies with access_denied/email_not_verified.
+      const isEmailNotVerified =
+        (router.query.error_description === "401" &&
+          router.query.error === "unauthorized") ||
+        (router.query.error === "access_denied" &&
+          router.query.error_description === "email_not_verified");
+      if (isEmailNotVerified) {
         router.replace({
           query: { to: router.query.to, step: router.query.step },
         });


### PR DESCRIPTION
The Auth0 PostLogin Action now denies unverified logins with access_denied/email_not_verified instead of unauthorized/401. Match the new shape so the verify-email path (hide login) still triggers.
