### PR TITLE
Fix sessionId generation to use UUID v7

### DIFF
--- a/src/Utils/api.ts
+++ b/src/Utils/api.ts
@@ -1,6 +1,6 @@
 import getsessionId from "./getSessionId";
 import axios, { AxiosRequestConfig, Method } from "axios";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidV4 } from "uuid";
 import { APIError } from "@planet-sdk/common";
 import { Dispatch, SetStateAction } from "react";
 
@@ -134,7 +134,7 @@ export const apiRequest = async (
     // append all the additional headers to the request
     options.headers = {
       ...options.headers,
-      ...(addIdempotencyKeyHeader && { "IDEMPOTENCY-KEY": uuidv4() }),
+      ...(addIdempotencyKeyHeader && { "IDEMPOTENCY-KEY": uuidV4() }),
       ...headers,
     };
 

--- a/src/Utils/getSessionId.ts
+++ b/src/Utils/getSessionId.ts
@@ -1,4 +1,4 @@
-import { v1 } from "uuid";
+import { v7 as uuidV7 } from "uuid";
 
 /**
  * Async function to return a sessionId string
@@ -10,14 +10,14 @@ export default async function getsessionId(): Promise<string> {
     if (typeof window !== "undefined") {
       sessionId = localStorage.getItem("sessionId");
     } else {
-      sessionId = v1();
+      sessionId = uuidV7();
     }
     if (!sessionId) {
-      sessionId = v1();
+      sessionId = uuidV7();
       localStorage.setItem("sessionId", sessionId);
     }
   } else {
-    sessionId = v1();
+    sessionId = uuidV7();
     if (typeof window !== "undefined") {
       localStorage.setItem("sessionId", sessionId);
     }


### PR DESCRIPTION
Update the sessionId generation method to utilize UUID v7 instead of UUID v1 for improved uniqueness and standardization. 

v1 UUIDs encode the MAC address and timestamp, which leaks hardware identity. v7 UUIDs are time-ordered and use random data instead, so are more private.

Fixes #601